### PR TITLE
Dataset details page

### DIFF
--- a/app/database/interface.py
+++ b/app/database/interface.py
@@ -182,3 +182,15 @@ class CatalogDBInterface:
             "total_pages": (total + per_page - 1) // per_page,
             "records": [self.to_dict(record) for record in items],
         }
+
+    def get_dataset_by_slug(self, dataset_slug: str) -> Dataset | None:
+        """
+        Get dataset by its slug.
+        """
+        return self.db.query(Dataset).filter_by(slug=dataset_slug).first()
+
+    def get_dataset_by_id(self, dataset_id: str) -> Dataset | None:
+        """
+        Get dataset by its guid.
+        """
+        return self.db.query(Dataset).filter_by(id=dataset_id).first()

--- a/app/routes.py
+++ b/app/routes.py
@@ -14,6 +14,7 @@ from flask import (
     render_template,
     request,
     url_for,
+    abort,
 )
 
 from .database import CatalogDBInterface
@@ -202,6 +203,29 @@ def organization_detail(slug: str):
         "organization_detail.html",
         organization=organization_data,
         sources=sources,
+    )
+
+
+@main.route("/dataset/slug/<dataset_slug>", methods=["GET"])
+def dataset_detail_by_slug(dataset_slug: str):
+    dataset = interface.get_dataset_by_slug(dataset_slug)
+    if dataset is None:
+        abort(404)
+    return render_template(
+        "dataset_detail.html",
+        dataset=dataset,
+    )
+
+
+@valid_id_required
+@main.route("/dataset/id/<dataset_id>", methods=["GET"])
+def dataset_detail_by_id(dataset_id: str):
+    dataset = interface.get_dataset_by_id(dataset_id)
+    if dataset is None:
+        abort(404)
+    return render_template(
+        "dataset_detail.html",
+        dataset=dataset,
     )
 
 

--- a/app/templates/dataset_detail.html
+++ b/app/templates/dataset_detail.html
@@ -47,22 +47,6 @@
                     </div>
                 </section>
                 {% endif %}
-
-                {% if dataset.dcat.get('contactPoint') or dataset.dcat.get('license') %}
-                <section class="margin-bottom-4">
-                    <h2 class="text-primary-darker">Additional Information</h2>
-                    <dl class="usa-prose">
-                        {% if dataset.dcat.get('contactPoint') %}
-                        <dt class="text-bold">Contact</dt>
-                        <dd>{{ dataset.dcat.contactPoint }}</dd>
-                        {% endif %}
-                        {% if dataset.dcat.get('license') %}
-                        <dt class="text-bold">License</dt>
-                        <dd>{{ dataset.dcat.license }}</dd>
-                        {% endif %}
-                    </dl>
-                </section>
-                {% endif %}
             </div>
 
             <div class="desktop:grid-col-4">

--- a/app/templates/dataset_detail.html
+++ b/app/templates/dataset_detail.html
@@ -1,0 +1,105 @@
+{% extends "base.html" %}
+
+{% block title %}{{ dataset.dcat.title }} - Data.gov{% endblock %}
+
+{% block content %}
+<div class="usa-section">
+    <div class="grid-container">
+        <nav class="usa-breadcrumb" aria-label="Breadcrumbs">
+            <ol class="usa-breadcrumb__list">
+                <li class="usa-breadcrumb__list-item">
+                    <a href="{{ url_for('main.index') }}" class="usa-breadcrumb__link">Home</a>
+                </li>
+                <li class="usa-breadcrumb__list-item">
+                    <a href="#" class="usa-breadcrumb__link">Datasets</a>
+                </li>
+                <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
+                    <span>{{ dataset.dcat.title }}</span>
+                </li>
+            </ol>
+        </nav>
+
+        <div class="grid-row margin-top-4">
+            <div class="grid-col-12">
+                <h1 class="margin-bottom-1">{{ dataset.dcat.title }}</h1>
+                {% if dataset.dcat.get('publisher', {}).get('name') %}
+                <p class="usa-intro text-base-dark margin-top-0">
+                    Published by {{ dataset.dcat.publisher.name }}
+                </p>
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="grid-row grid-gap-lg margin-top-4">
+            <div class="desktop:grid-col-8">
+                <section class="margin-bottom-4">
+                    <h2 class="text-primary-darker">Description</h2>
+                    <p class="usa-prose">{{ dataset.dcat.description }}</p>
+                </section>
+
+                {% if dataset.dcat.get('keyword') %}
+                <section class="margin-bottom-4">
+                    <h2 class="text-primary-darker">Tags</h2>
+                    <div>
+                        {% for keyword in dataset.dcat.keyword %}
+                        <span class="usa-tag margin-right-05 margin-bottom-05">{{ keyword }}</span>
+                        {% endfor %}
+                    </div>
+                </section>
+                {% endif %}
+
+                {% if dataset.dcat.get('contactPoint') or dataset.dcat.get('license') %}
+                <section class="margin-bottom-4">
+                    <h2 class="text-primary-darker">Additional Information</h2>
+                    <dl class="usa-prose">
+                        {% if dataset.dcat.get('contactPoint') %}
+                        <dt class="text-bold">Contact</dt>
+                        <dd>{{ dataset.dcat.contactPoint }}</dd>
+                        {% endif %}
+                        {% if dataset.dcat.get('license') %}
+                        <dt class="text-bold">License</dt>
+                        <dd>{{ dataset.dcat.license }}</dd>
+                        {% endif %}
+                    </dl>
+                </section>
+                {% endif %}
+            </div>
+
+            <div class="desktop:grid-col-4">
+                <div>
+                    <div class="usa-card__container">
+                        <div class="usa-card__header">
+                            <h4 class="usa-card__heading">Dataset Information</h3>
+                        </div>
+                        <div class="usa-card__body">
+                            <dl>
+                                <dt class="text-bold margin-top-2">Last Harvested</dt>
+                                <dd class="margin-bottom-2">
+                                    {% if dataset.last_harvested_date %}
+                                    {{ dataset.last_harvested_date.strftime('%B %d, %Y at %I:%M %p') }}
+                                    {% else %}
+                                    Not available
+                                    {% endif %}
+                                </dd>
+
+                                <dt class="text-bold margin-top-2">Popularity Score</dt>
+                                <dd class="margin-bottom-2">
+                                    <span class="text-bold text-primary">{{ dataset.popularity or 'N/A' }}</span>
+                                </dd>
+
+                                <dt class="text-bold margin-top-2">Harvest Record</dt>
+                                <dd class="margin-bottom-0">
+                                    <a href="{{ url_for('main.get_harvest_record', record_id=dataset.harvest_record_id) }}"
+                                        class="usa-link">
+                                        View Record
+                                    </a>
+                                </dd>
+                            </dl>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,7 @@ def interface_with_dataset(interface_with_harvest_record):
 
     interface_with_harvest_record.db.add(
         Dataset(
+            id="5dafad8f-4338-4602-84ca-010ee1adf9a0",
             slug="test",
             dcat={"title": "test", "description": "this is the test description"},
             harvest_record_id="1",

--- a/tests/test_dataset_detail.py
+++ b/tests/test_dataset_detail.py
@@ -1,0 +1,16 @@
+class TestDatasetDetail:
+    """
+    Test cases for dataset detail page.
+    """
+
+    def test_dataset_detail_by_slug(self, interface_with_dataset):
+        dataset = interface_with_dataset.get_dataset_by_slug("test")
+        assert dataset is not None
+        assert dataset.dcat.get("title") == "test"
+
+    def test_dataset_detail_by_id(self, interface_with_dataset):
+        dataset = interface_with_dataset.get_dataset_by_id(
+            "5dafad8f-4338-4602-84ca-010ee1adf9a0"
+        )
+        assert dataset is not None
+        assert dataset.dcat.get("title") == "test"


### PR DESCRIPTION
Ticket: GSA/data.gov#5494

Features:
- Adds Dataset Detail Page
    - In the ticket it notes that slugs may not be entirely reliable so there are 2 routes to the Detail page:
        - `/dataset/id/<dataset_id>`
        - `/dataset/slug/<dataset_slug>`
    - Adds db interface functions to look up dataset's by ID and slug
    - To help mimic OG catalog this mock includes: breadcrumbs, title, description, last pub date, pub date, link to harvest record (currently the API page)