### PR TITLE
fix sections wear overflow was occuring, add margin for metadrop down

### DIFF
--- a/app/static/_scss/_uswds-theme-custom-styles.scss
+++ b/app/static/_scss/_uswds-theme-custom-styles.scss
@@ -537,6 +537,7 @@ ul.dataset-resources {
 
 .sidebar-section__item {
     margin-bottom: 1rem;
+    word-wrap: break-word;
 }
 
 .sidebar-section__item:last-child {
@@ -555,6 +556,14 @@ ul.dataset-resources {
 .sidebar-section__value {
     font-size: 1rem;
     color: #1b1b1b;
+}
+
+details {
+  summary {
+    @media (max-width: 700px) {
+      margin-bottom: 1.5em;
+    }
+  }
 }
 
 .metadata-table {


### PR DESCRIPTION
Ticket: gsa/data.gov#5736

Changes are on dev:
https://datagov-catalog-dev.app.cloud.gov/dataset/crime-data-from-2020-to-present

Fixes:
- It seems the width for the metadata field was already fixed. After testing it multiple times in different views the width look fine. It seems there was a [commit](https://github.com/GSA/datagov-catalog/blame/37bd3bce746146989380d09e35afd123250a9f42/app/static/_scss/_uswds-theme-custom-styles.scss#L571) awhile ago that fixed metadata field. The only time where I don't think it would be optimal would be a case where we only have small field names, but trying to account for that would cause the metadata table to look weird on all pages.
- Fixed a word wrap issue with the access section, access urls will now break apart instead of going out of the box.
- Added a margin-bottom to the Complete Metadata button section to help give it space instead of it looking clumped up.