### PR TITLE
map to catalog.data.gov

### DIFF
--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -7,5 +7,5 @@ instances: 4
 
 proxy_instances: 2
 basic_auth_enabled: off # nginx terminology 'on' 'off'. cf will interpret these as 'true' 'false'
-route_external: catalog-beta.data.gov
+route_external: catalog.data.gov
 route_internal: datagov-catalog-prod.apps.internal


### PR DESCRIPTION
taking down catalog-beta.data.gov, use catalog.data.gov