### PR TITLE
add "beta" redirect route for dev; fix beta redirect

### DIFF
--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -28,12 +28,10 @@ http {
   }
 
   server {
+    listen {{port}};
     server_name {{env "BETA_ROUTE"}};
 
-    location / {
-      set $backend_servers $internal_url:61443;
-      proxy_pass https://${backend_servers}${request_uri};
-    }
+    return 301 https://{{env "EXTERNAL_ROUTE"}}$request_uri;
   }
 
   ## Gunicorn specs

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -8,5 +8,5 @@ instances: 1
 proxy_instances: 1
 basic_auth_enabled: on # nginx terminology 'on' 'off'. cf will interpret these as 'true' 'false'
 route_external: datagov-catalog-dev.app.cloud.gov
-route_beta: unused-development-redirect.invalid # an invalid url because there's no 'beta' equivalent
+route_beta: catalog-beta-dev.app.cloud.gov # an invalid url because there's no 'beta' equivalent
 route_internal: datagov-catalog-dev.apps.internal


### PR DESCRIPTION
works on dev at https://catalog-beta-dev.app.cloud.gov