### PR TITLE
dev/stage use data.gov domain

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -130,7 +130,7 @@ jobs:
           poetry-version: ${{ env.POETRY_VERSION }}
           cf_username: ${{ secrets.CF_SERVICE_USER }}
           cf_password: ${{ secrets.CF_SERVICE_AUTH }}
-          smoke-url: https://datagov-catalog-dev.app.cloud.gov/
+          smoke-url: https://catalog-dev.data.gov/
           smoke-path: /
           basic_auth_user: ${{ secrets.BASIC_AUTH_USER }}
           basic_auth_password: ${{ secrets.BASIC_AUTH_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           poetry-version: ${{ env.POETRY_VERSION }}
           cf_username: ${{ secrets.CF_SERVICE_USER }}
           cf_password: ${{ secrets.CF_SERVICE_AUTH }}
-          smoke-url: https://datagov-catalog-staging.app.cloud.gov/
+          smoke-url: https://catalog-stage.data.gov/
           smoke-path: /
           basic_auth_user: ${{ secrets.BASIC_AUTH_USER }}
           basic_auth_password: ${{ secrets.BASIC_AUTH_PASSWORD }}

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -1,12 +1,12 @@
 ---
 app_name: datagov-catalog
-site_url: https://datagov-catalog-dev.app.cloud.gov
+site_url: https://catalog-dev.data.gov
 new_relic_app_name: datagov-catalog-dev
 new_relic_monitor_mode: false
 instances: 1
 
 proxy_instances: 1
 basic_auth_enabled: on # nginx terminology 'on' 'off'. cf will interpret these as 'true' 'false'
-route_external: datagov-catalog-dev.app.cloud.gov
+route_external: catalog-dev.data.gov
 route_beta: catalog-beta-dev.app.cloud.gov # an invalid url because there's no 'beta' equivalent
 route_internal: datagov-catalog-dev.apps.internal

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -1,12 +1,12 @@
 ---
 app_name: datagov-catalog
-site_url: https://datagov-catalog-staging.app.cloud.gov
+site_url: https://catalog-stage.data.gov
 new_relic_app_name: datagov-catalog-staging
 new_relic_monitor_mode: true
 instances: 1
 
 proxy_instances: 2
 basic_auth_enabled: on # nginx terminology 'on' 'off'. cf will interpret these as 'true' 'false'
-route_external: datagov-catalog-staging.app.cloud.gov
+route_external: catalog-stage.data.gov
 route_beta: unused-staging-redirect.invalid # an invalid url because there's no 'beta' equivalent
 route_internal: datagov-catalog-staging.apps.internal


### PR DESCRIPTION
catalog-dev.data.gov
catalog-stage.data.gov

This brings the dev and stage environments closer to the production configuration.