### PR TITLE
`landingPage` Value in MetaData should be Link

### DIFF
--- a/app/templates/dataset_detail.html
+++ b/app/templates/dataset_detail.html
@@ -286,7 +286,9 @@
                                 <tr>
                                     <th scope="row">{{ key }}</th>
                                     <td>
-                                        {% if rendered_value | is_json %}
+                                        {% if key == 'landingPage' %}
+                                        <a href="{{ value }}" target="_blank" rel="noopener">{{ value }}</a>
+                                        {% elif rendered_value | is_json %}
                                         <pre class="json">
                                             {{ value | json_to_semantic_html | safe }}
                                         </pre>

--- a/tests/test_dataset_detail.py
+++ b/tests/test_dataset_detail.py
@@ -330,6 +330,40 @@ class TestDatasetDetail:
         )
         assert collection_link is not None
 
+    def test_metadata_landing_page_is_anchor(self, interface_with_dataset, db_client):
+        """
+        Test that the landingPage key in the Complete Metadata section
+        is rendered as an anchor tag.
+        """
+        landing_page_url = "https://example.com/landing-page"
+        ds = interface_with_dataset.get_dataset_by_slug("test")
+        ds.dcat = {**ds.dcat, "landingPage": landing_page_url}
+        interface_with_dataset.db.commit()
+
+        with patch("app.routes.interface", interface_with_dataset):
+            response = db_client.get("/dataset/test")
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        metadata_table = soup.select_one("table.metadata-table")
+        assert metadata_table is not None
+
+        landing_page_row = next(
+            (
+                row
+                for row in metadata_table.select("tr")
+                if row.select_one("th").get_text(strip=True) == "landingPage"
+            ),
+            None,
+        )
+        assert landing_page_row is not None
+
+        anchor = landing_page_row.select_one("td a")
+        assert anchor is not None
+        assert anchor.get("href") == landing_page_url
+        assert anchor.get_text(strip=True) == landing_page_url
+
     def test_check_jsonld(self, interface_with_dataset, db_client):
 
         with patch("app.routes.interface", interface_with_dataset):


### PR DESCRIPTION
Ticket: GSA/data.gov#5860

Change:
- Turns the landingPage value to an anchor