### PR TITLE
Make Date Time Wording More Uniform

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,7 @@ from flask_talisman import Talisman
 from .filters import (
     fa_icon_from_extension,
     format_contact_point_email,
+    format_dcat_date,
     format_dcat_value,
     format_gov_type,
     geometry_to_mapping,
@@ -16,6 +17,7 @@ from .filters import (
     is_geometry_mapping,
     is_json,
     json_to_semantic_html,
+    parse_datetime,
     remove_html_tags,
     simplify_resource_type,
     usa_icon,
@@ -85,6 +87,8 @@ def create_app(config_name: str = "local") -> APIFlask:
     app.add_template_filter(simplify_resource_type)
     app.add_template_filter(json_to_semantic_html)
     app.add_template_filter(is_json)
+    app.add_template_filter(parse_datetime)
+    app.add_template_filter(format_dcat_date)
 
     # Content-Security-Policy headers
     # single quotes need to appear in some of the strings

--- a/app/filters.py
+++ b/app/filters.py
@@ -233,6 +233,37 @@ def is_json(value):
         return False
 
 
+def parse_datetime(date_str: str) -> datetime | None:
+    """
+    Parse a date/datetime string into a datetime object.
+    """
+    if not isinstance(date_str, str):
+        return None
+    date_str = date_str.strip()
+    if not date_str:
+        return None
+    normalized = date_str.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        pass
+    try:
+        date_info = date.fromisoformat(date_str[:10])
+        return datetime(date_info.year, date_info.month, date_info.day)
+    except ValueError:
+        return None
+
+
+def format_dcat_date(value: datetime | None) -> str | None:
+    if value is None or not isinstance(value, datetime):
+        return None
+
+    has_time = value.hour != 0 or value.minute != 0 or value.second != 0
+    if has_time:
+        return value.strftime("%B %d, %Y at %I:%M %p")
+    return value.strftime("%B %d, %Y")
+
+
 __all__ = [
     "usa_icon",
     "format_dcat_value",
@@ -246,4 +277,6 @@ __all__ = [
     "simplify_resource_type",
     "json_to_semantic_html",
     "is_json",
+    "parse_datetime",
+    "format_dcat_date",
 ]

--- a/app/filters.py
+++ b/app/filters.py
@@ -233,35 +233,35 @@ def is_json(value):
         return False
 
 
-def parse_datetime(date_str: str) -> datetime | None:
+def parse_datetime(date_str: str) -> datetime | date | None:
     """
-    Parse a date/datetime string into a datetime object.
+    Parse a date/datetime string into a datetime or date object.
     """
     if not isinstance(date_str, str):
         return None
     date_str = date_str.strip()
     if not date_str:
         return None
-    normalized = date_str.replace("Z", "+00:00")
+    if "T" in date_str:
+        normalized = date_str.replace("Z", "+00:00")
+        try:
+            return datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
     try:
-        return datetime.fromisoformat(normalized)
-    except ValueError:
-        pass
-    try:
-        date_info = date.fromisoformat(date_str[:10])
-        return datetime(date_info.year, date_info.month, date_info.day)
+        return date.fromisoformat(date_str[:10])
     except ValueError:
         return None
 
 
-def format_dcat_date(value: datetime | None) -> str | None:
-    if value is None or not isinstance(value, datetime):
+def format_dcat_date(value: datetime | date | None) -> str | None:
+    if value is None:
         return None
-
-    has_time = value.hour != 0 or value.minute != 0 or value.second != 0
-    if has_time:
+    if isinstance(value, datetime):
         return value.strftime("%B %d, %Y at %I:%M %p")
-    return value.strftime("%B %d, %Y")
+    if isinstance(value, date):
+        return value.strftime("%B %d, %Y")
+    return None
 
 
 __all__ = [

--- a/app/templates/components/dataset_card.j2
+++ b/app/templates/components/dataset_card.j2
@@ -65,7 +65,7 @@
               </li>
               {% if updated_display %}
               <li class="usa-collection__meta-item">
-                  <strong>Updated:</strong> {{ updated_display or 'Not available' }}
+                  <strong>Dataset Last Modified:</strong> {{ updated_display or 'Not available' }}
               </li>
               {% endif %}
           </ul>

--- a/app/templates/components/dataset_card.j2
+++ b/app/templates/components/dataset_card.j2
@@ -65,7 +65,7 @@
               </li>
               {% if updated_display %}
               <li class="usa-collection__meta-item">
-                  <strong>Dataset Last Modified:</strong> {{ updated_display | format_dcat_date or 'Not available' }}
+                  <strong>Dataset Last Updated:</strong> {{ updated_display | format_dcat_date or 'Not available' }}
               </li>
               {% endif %}
           </ul>

--- a/app/templates/components/dataset_card.j2
+++ b/app/templates/components/dataset_card.j2
@@ -4,7 +4,7 @@
 {% set dataset_meta = dataset.get('dcat', {}) if dataset.get('dcat') else {} %}
 {% set dataset_title = dataset_meta.get('title') or dataset.get('slug') or dataset.get('id') %}
 {% set dataset_slug = dataset.get('slug') %}
-{% set updated_display = dataset_meta.get('modified') %}
+{% set updated_display = dataset_meta.get('modified') | parse_datetime %}
 {% set view_count = dataset.get('popularity') %}
 {% set sort_values = dataset.get('_sort') %}
 {% set distance_km = none %}
@@ -65,7 +65,7 @@
               </li>
               {% if updated_display %}
               <li class="usa-collection__meta-item">
-                  <strong>Dataset Last Modified:</strong> {{ updated_display or 'Not available' }}
+                  <strong>Dataset Last Modified:</strong> {{ updated_display | format_dcat_date or 'Not available' }}
               </li>
               {% endif %}
           </ul>

--- a/app/templates/components/dataset_metrics.html
+++ b/app/templates/components/dataset_metrics.html
@@ -29,7 +29,7 @@
   {% set _ = metric_parts.append("Views last month: %s" % view_count) %}
 {% endif %}
 {% if last_harvested_text is not none %}
-  {% set _ = metric_parts.append("Metadata Last Checked: %s" % last_harvested_text) %}
+  {% set _ = metric_parts.append("Catalog Last Checked: %s" % last_harvested_text) %}
 {% endif %}
 {% if distance_km is not none %}
   {% set distance_mi = distance_km * 0.621371 %}

--- a/app/templates/components/dataset_metrics.html
+++ b/app/templates/components/dataset_metrics.html
@@ -3,10 +3,10 @@
 {% set search_score = dataset.get('_score') %}
 {% set metric_parts = [] %}
 {% set view_count = dataset.get('popularity') %}
-{% set published_on = dataset.get('last_harvested_date') %}
-{% set published_on_text = none %}
-{% if published_on is not none %}
-  {% set published_on_text = '%s' % published_on %}
+{% set last_harvested = dataset.get('last_harvested_date') %}
+{% set last_harvested_text = none %}
+{% if last_harvested is not none %}
+  {% set last_harvested_text = '%s' % last_harvested %}
 {% endif %}
 {% set distance_km = none %}
 {% if allow_distance %}
@@ -28,8 +28,8 @@
 {% elif view_count is not none %}
   {% set _ = metric_parts.append("Views last month: %s" % view_count) %}
 {% endif %}
-{% if published_on_text is not none %}
-  {% set _ = metric_parts.append("Published on: %s" % published_on_text[:10]) %}
+{% if last_harvested_text is not none %}
+  {% set _ = metric_parts.append("Metadata Last Checked: %s" % last_harvested_text[:10]) %}
 {% endif %}
 {% if distance_km is not none %}
   {% set distance_mi = distance_km * 0.621371 %}

--- a/app/templates/components/dataset_metrics.html
+++ b/app/templates/components/dataset_metrics.html
@@ -3,7 +3,7 @@
 {% set search_score = dataset.get('_score') %}
 {% set metric_parts = [] %}
 {% set view_count = dataset.get('popularity') %}
-{% set last_harvested = dataset.get('last_harvested_date') %}
+{% set last_harvested = dataset.get('last_harvested_date') | parse_datetime | format_dcat_date %}
 {% set last_harvested_text = none %}
 {% if last_harvested is not none %}
   {% set last_harvested_text = '%s' % last_harvested %}
@@ -29,7 +29,7 @@
   {% set _ = metric_parts.append("Views last month: %s" % view_count) %}
 {% endif %}
 {% if last_harvested_text is not none %}
-  {% set _ = metric_parts.append("Metadata Last Checked: %s" % last_harvested_text[:10]) %}
+  {% set _ = metric_parts.append("Metadata Last Checked: %s" % last_harvested_text) %}
 {% endif %}
 {% if distance_km is not none %}
   {% set distance_mi = distance_km * 0.621371 %}

--- a/app/templates/dataset_detail.html
+++ b/app/templates/dataset_detail.html
@@ -97,11 +97,11 @@
                         }}</a>
                     {% endif %}
                     {% if dataset.last_harvested_date %}
-                    | Metadata Last Checked: <strong>{{ dataset.last_harvested_date.strftime('%B %d, %Y') }}</strong>
+                    | Metadata Last Checked: <strong>{{ dataset.last_harvested_date | format_dcat_date }}</strong>
                     {% endif %}
                     {% set modified_dt = dataset.dcat.get('modified') | parse_datetime %}
                     {% if modified_dt %}
-                    | Dataset Last Modified: <strong>{{ modified_dt.strftime('%B %d, %Y') }}</strong>
+                    | Dataset Last Modified: <strong>{{ modified_dt | format_dcat_date }}</strong>
                     {% endif %}
                 </div>
 
@@ -406,7 +406,7 @@
                     <div class="sidebar-section__item">
                         <div class="sidebar-section__label">Metadata Last Checked</div>
                         <div class="sidebar-section__value">
-                            {{ dataset.last_harvested_date.strftime('%B %d, %Y at %I:%M %p') }}
+                            {{ dataset.last_harvested_date | format_dcat_date }}
                         </div>
                     </div>
                     {% endif %}

--- a/app/templates/dataset_detail.html
+++ b/app/templates/dataset_detail.html
@@ -99,8 +99,9 @@
                     {% if dataset.last_harvested_date %}
                     | Metadata Last Checked: <strong>{{ dataset.last_harvested_date.strftime('%B %d, %Y') }}</strong>
                     {% endif %}
-                    {% if dataset.dcat.get('modified') %}
-                    | Last Modified: <strong>{{ dataset.dcat.modified }}</strong>
+                    {% set modified_dt = dataset.dcat.get('modified') | parse_datetime %}
+                    {% if modified_dt %}
+                    | Dataset Last Modified: <strong>{{ modified_dt.strftime('%B %d, %Y') }}</strong>
                     {% endif %}
                 </div>
 
@@ -182,16 +183,16 @@
                     </ul>
                 </div>
                 {% endif %}
-                
+
                 <h2 class="text-primary-darker margin-bottom-1">Find Related Datasets</h2>
                 <section class="usa-section bg-base-lightest radius-lg padding-3 margin-top-4">
 
                     <div class="grid-row grid-gap-lg">
-                        
+
                         {% if dataset.dcat.get('keyword') %}
                         <div class="tablet:grid-col-6">
                         <div class="padding-3 bg-white radius-lg border border-base-lighter height-full">
-                            
+
                             <h4 class="margin-top-0 display-flex flex-align-center">
                             Search by Tags
                             </h4>
@@ -235,8 +236,8 @@
 
                         </div>
                         </div>
-                        {% endif %} 
-                        
+                        {% endif %}
+
                         {% set collection_total = collection_data.get('count') - 1 %}
                         {% if collection_total > 0 %}
                         <div class="tablet:grid-col-6 collection-tooltip">
@@ -268,11 +269,11 @@
                             </div>
                         </div>
                         </div>
-                        {% endif %} 
+                        {% endif %}
 
                     </div>
                 </section>
-                
+
                 <details class="margin-bottom-3 margin-top-3">
                     <summary>
                         <h2 class="complete-metadata-heading">Complete Metadata</h2>
@@ -356,20 +357,22 @@
                 <div class="sidebar-section">
                     <h3 class="sidebar-section__heading">Dataset Information</h3>
 
-                    {% if dataset.dcat.get('issued') %}
+                    {% set issued_dt = dataset.dcat.get('issued') | parse_datetime %}
+                    {% if issued_dt %}
                     <div class="sidebar-section__item">
                         <div class="sidebar-section__label">Dataset Issued</div>
                         <div class="sidebar-section__value">
-                            {{ dataset.dcat.get('issued') }}
+                            {{ issued_dt | format_dcat_date }}
                         </div>
                     </div>
                     {% endif %}
 
-                    {% if dataset.dcat.get('modified') %}
+                    {% set modified_dt = dataset.dcat.get('modified') | parse_datetime %}
+                    {% if modified_dt %}
                     <div class="sidebar-section__item">
                         <div class="sidebar-section__label">Dataset Last Modified</div>
                         <div class="sidebar-section__value">
-                            {{ dataset.dcat.get('modified') }}
+                            {{ modified_dt | format_dcat_date }}
                         </div>
                     </div>
                     {% endif %}

--- a/app/templates/dataset_detail.html
+++ b/app/templates/dataset_detail.html
@@ -97,11 +97,11 @@
                         }}</a>
                     {% endif %}
                     {% if dataset.last_harvested_date %}
-                    | Metadata Last Checked: <strong>{{ dataset.last_harvested_date | format_dcat_date }}</strong>
+                    | Catalog Last Checked: <strong>{{ dataset.last_harvested_date | format_dcat_date }}</strong>
                     {% endif %}
                     {% set modified_dt = dataset.dcat.get('modified') | parse_datetime %}
                     {% if modified_dt %}
-                    | Dataset Last Modified: <strong>{{ modified_dt | format_dcat_date }}</strong>
+                    | Dataset Last Updated: <strong>{{ modified_dt | format_dcat_date }}</strong>
                     {% endif %}
                 </div>
 
@@ -360,7 +360,7 @@
                     {% set issued_dt = dataset.dcat.get('issued') | parse_datetime %}
                     {% if issued_dt %}
                     <div class="sidebar-section__item">
-                        <div class="sidebar-section__label">Dataset Issued</div>
+                        <div class="sidebar-section__label">Dataset First Published</div>
                         <div class="sidebar-section__value">
                             {{ issued_dt | format_dcat_date }}
                         </div>
@@ -370,7 +370,7 @@
                     {% set modified_dt = dataset.dcat.get('modified') | parse_datetime %}
                     {% if modified_dt %}
                     <div class="sidebar-section__item">
-                        <div class="sidebar-section__label">Dataset Last Modified</div>
+                        <div class="sidebar-section__label">Dataset Last Updated</div>
                         <div class="sidebar-section__value">
                             {{ modified_dt | format_dcat_date }}
                         </div>
@@ -404,7 +404,7 @@
 
                     {% if dataset.last_harvested_date %}
                     <div class="sidebar-section__item">
-                        <div class="sidebar-section__label">Metadata Last Checked</div>
+                        <div class="sidebar-section__label">Catalog Last Checked</div>
                         <div class="sidebar-section__value">
                             {{ dataset.last_harvested_date | format_dcat_date }}
                         </div>

--- a/tests/unit/test_dataset_detail.py
+++ b/tests/unit/test_dataset_detail.py
@@ -98,10 +98,10 @@ class TestDatasetDetail:
             .get_text(strip=True)
             for item in dataset_info_box.select(".sidebar-section__item")
         }
-        assert "Dataset Issued" in dataset_info_items
-        assert dataset_info_items["Dataset Issued"] == "March 15, 2021"
-        assert "Dataset Last Modified" in dataset_info_items
-        assert dataset_info_items["Dataset Last Modified"] == "June 01, 2023"
+        assert "Dataset First Published" in dataset_info_items
+        assert dataset_info_items["Dataset First Published"] == "March 15, 2021"
+        assert "Dataset Last Updated" in dataset_info_items
+        assert dataset_info_items["Dataset Last Updated"] == "June 01, 2023"
         assert "Accrual Periodicity" in dataset_info_items
         assert dataset_info_items["Accrual Periodicity"] == "R/P1Y"
 
@@ -117,8 +117,8 @@ class TestDatasetDetail:
         expected_harvested = DEFAULT_LAST_HARVESTED_DATE.strftime(
             "%B %d, %Y at %I:%M %p"
         )
-        assert "Metadata Last Checked" in metadata_items
-        assert metadata_items["Metadata Last Checked"] == expected_harvested
+        assert "Catalog Last Checked" in metadata_items
+        assert metadata_items["Catalog Last Checked"] == expected_harvested
 
         harvest_record_item = metadata_items.get("Harvest Record")
         assert harvest_record_item is not None

--- a/tests/unit/test_dataset_detail.py
+++ b/tests/unit/test_dataset_detail.py
@@ -99,9 +99,9 @@ class TestDatasetDetail:
             for item in dataset_info_box.select(".sidebar-section__item")
         }
         assert "Dataset Issued" in dataset_info_items
-        assert dataset_info_items["Dataset Issued"] == "2021-03-15"
+        assert dataset_info_items["Dataset Issued"] == "March 15, 2021"
         assert "Dataset Last Modified" in dataset_info_items
-        assert dataset_info_items["Dataset Last Modified"] == "2023-06-01"
+        assert dataset_info_items["Dataset Last Modified"] == "June 01, 2023"
         assert "Accrual Periodicity" in dataset_info_items
         assert dataset_info_items["Accrual Periodicity"] == "R/P1Y"
 
@@ -393,3 +393,38 @@ class TestDatasetDetail:
         }
 
         assert jsonld == expected
+
+    @pytest.mark.parametrize(
+        "modified_value, expected_display",
+        [
+            ("2023-06-01", "June 01, 2023"),
+            ("2023-06-01T00:00:00", "June 01, 2023"),
+            ("2023-06-01T12:34:56Z", "June 01, 2023"),
+            ("2023-06-01T12:34:56+00:00", "June 01, 2023"),
+        ],
+    )
+    def test_title_meta_dataset_last_modified_iso_formats(
+        self,
+        modified_value,
+        expected_display,
+        interface_with_dataset,
+        db_client,
+    ):
+        """
+        parse_datetime handles the full range of ISO 8601 strings that may
+        appear in the DCAT 'modified' field; all should produce the same
+        human-readable date in the .dataset-meta bar.
+        """
+        ds = interface_with_dataset.get_dataset_by_slug("test")
+        ds.dcat = {**ds.dcat, "modified": modified_value}
+        interface_with_dataset.db.commit()
+
+        with patch("app.routes.interface", interface_with_dataset):
+            response = db_client.get("/dataset/test")
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        meta_bar = soup.select_one(".dataset-meta")
+        assert meta_bar is not None
+        assert expected_display in meta_bar.get_text(" ", strip=True)

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -1,4 +1,10 @@
-from app.filters import remove_html_tags, simplify_resource_type
+import pytest
+
+from app.filters import (
+    parse_datetime,
+    remove_html_tags,
+    simplify_resource_type,
+)
 
 
 def test_remove_html_tags(html_tags_within_text):
@@ -32,3 +38,23 @@ class TestSimplifyResourceType:
 
     def test_none_returns_none(self):
         assert simplify_resource_type(None) is None
+
+
+class TestParseDatetime:
+    """
+    Tests for the `parse_datetime` filter.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "2026-05-01",
+            "2026-05-01T00:00:00",
+            "2026-05-01T00:00:00Z",
+            "2026-05-01T00:00:00+00:00",
+        ],
+    )
+    def test_common_dcat_formats_parse_to_may_01(self, value):
+        result = parse_datetime(value)
+        assert result is not None
+        assert (result.year, result.month, result.day) == (2026, 5, 1)

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -1,6 +1,9 @@
+from datetime import date, datetime
+
 import pytest
 
 from app.filters import (
+    format_dcat_date,
     parse_datetime,
     remove_html_tags,
     simplify_resource_type,
@@ -41,20 +44,37 @@ class TestSimplifyResourceType:
 
 
 class TestParseDatetime:
-    """
-    Tests for the `parse_datetime` filter.
-    """
+
+    def test_date_only_string_returns_date(self):
+        result = parse_datetime("2026-05-01")
+        assert type(result) is date
+        assert result == date(2026, 5, 1)
 
     @pytest.mark.parametrize(
         "value",
         [
-            "2026-05-01",
             "2026-05-01T00:00:00",
             "2026-05-01T00:00:00Z",
             "2026-05-01T00:00:00+00:00",
         ],
     )
-    def test_common_dcat_formats_parse_to_may_01(self, value):
+    def test_datetime_strings_return_datetime(self, value):
         result = parse_datetime(value)
-        assert result is not None
+        assert type(result) is datetime
         assert (result.year, result.month, result.day) == (2026, 5, 1)
+
+
+class TestFormatDcatDate:
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("2026-05-01", "May 01, 2026"),
+            ("2026-05-01T14:48:00", "May 01, 2026 at 02:48 PM"),
+            ("2026-05-01T14:48:00Z", "May 01, 2026 at 02:48 PM"),
+            ("2026-05-01T14:48:00+00:00", "May 01, 2026 at 02:48 PM"),
+            ("2026-05-01T00:00:00", "May 01, 2026 at 12:00 AM"),
+        ],
+    )
+    def test_round_trip_via_parse_datetime(self, raw, expected):
+        assert format_dcat_date(parse_datetime(raw)) == expected

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -1491,7 +1491,7 @@ def test_index_search_result_includes_published_on_in_metrics_line(db_client):
     metadata_line = first_item.find("small", class_="text-base-dark")
     assert metadata_line is not None
     assert (
-        "Search relevance: 1.00 | Views last month: 0 | Published on: 2024-01-15"
+        "Search relevance: 1.00 | Views last month: 0 | Metadata Last Checked: 2024-01-15"
         in metadata_line.get_text(" ", strip=True)
     )
 

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -1491,7 +1491,7 @@ def test_index_search_result_includes_published_on_in_metrics_line(db_client):
     metadata_line = first_item.find("small", class_="text-base-dark")
     assert metadata_line is not None
     assert (
-        "Search relevance: 1.00 | Views last month: 0 | Metadata Last Checked: January 15, 2024 at 12:30 PM"
+        "Search relevance: 1.00 | Views last month: 0 | Catalog Last Checked: January 15, 2024 at 12:30 PM"
         in metadata_line.get_text(" ", strip=True)
     )
 

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -1491,7 +1491,7 @@ def test_index_search_result_includes_published_on_in_metrics_line(db_client):
     metadata_line = first_item.find("small", class_="text-base-dark")
     assert metadata_line is not None
     assert (
-        "Search relevance: 1.00 | Views last month: 0 | Metadata Last Checked: 2024-01-15"
+        "Search relevance: 1.00 | Views last month: 0 | Metadata Last Checked: January 15, 2024 at 12:30 PM"
         in metadata_line.get_text(" ", strip=True)
     )
 


### PR DESCRIPTION
Ticket: GSA/data.gov#5806

- Cleans up wording
    - **"Dataset Last Modified"** = When a dataset was modified by publisher/owners (comes from DCAT `modified` field)
    - **"Dataset Issued"** = When a dataset was issued by publisher/owners (comes from DCAT `issued` field)
    - **"Metadata Last Checked"** = When Harvester last harvested the metadata
- Adds filters to help take different time strings and translates them to datetime objects that can be more easily formated
- Format function for date/datetime objects to help with making formats more uniform

**_Changes live on dev_**
