### PR TITLE
fix tag expand button

### DIFF
--- a/app/templates/dataset_detail.html
+++ b/app/templates/dataset_detail.html
@@ -41,7 +41,6 @@
 </script>
 {% endblock %}
 
-<script src="{{ url_for('static', filename='js/dataset_tags.js') }}"></script>
 
 {% block head_extra %}
 {% set description_value = dataset.dcat.get('description') %}
@@ -443,6 +442,7 @@
 {% block scripts %}
 {{ super() }}
 <script src="{{ url_for('static', filename='js/dataset_feedback.js') }}"></script>
+<script src="{{ url_for('static', filename='js/dataset_tags.js') }}"></script>
 {% if dataset.translated_spatial %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/vendor/leaflet.css') }}" />
 <script src="{{ url_for('static', filename='js/vendor/leaflet.js') }}"></script>

--- a/tests/browser/test_dataset.py
+++ b/tests/browser/test_dataset.py
@@ -1,3 +1,5 @@
+import re
+
 from playwright.sync_api import expect
 
 """Test the dataset details page."""
@@ -8,3 +10,35 @@ def test_dataset_details(page):
     expect(page.get_by_role("heading", level=1)).to_have_text(
         "Climate Change Environmental Data"
     )
+
+
+def test_dataset_tags_expand_button(page):
+    page.goto("/dataset/parent-harvest-record")
+
+    button = page.locator(".show-more-btn")
+    extra_tags = page.locator(".extra-tags")
+    hidden_tag_links = extra_tags.locator(".tag-link")
+
+    initial_text = button.inner_text()
+    expected_count = int(re.search(r"\d+", initial_text).group())
+
+    assert expected_count == 42
+
+    expect(button).to_be_visible()
+    expect(button).to_have_text(f"+ {expected_count} more")
+
+    # Hidden by default
+    expect(extra_tags).to_have_class(re.compile(r"display-none"))
+    expect(hidden_tag_links).to_have_count(expected_count)
+
+    # Expand hidden tags
+    button.click()
+
+    expect(extra_tags).not_to_have_class(re.compile(r"display-none"))
+    expect(button).to_have_text("Show less")
+
+    # Collapse hidden tags
+    button.click()
+
+    expect(extra_tags).to_have_class(re.compile(r"display-none"))
+    expect(button).to_have_text(f"+ {expected_count} more")


### PR DESCRIPTION
related to [5888](https://github.com/GSA/data.gov/issues/5888)

`dataset_tag.js` wasn't being executed where it was. moved to scripts block has it running as intended.

[dataset](https://catalog-dev.data.gov/dataset/motor-vehicle-collisions-crashes) on dev