### PR TITLE
add dcatus to schema.org json ld format for google search

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,20 +6,6 @@ from dotenv import load_dotenv
 from flask_htmx import HTMX
 from flask_talisman import Talisman
 
-from .filters import (
-    fa_icon_from_extension,
-    format_contact_point_email,
-    format_dcat_value,
-    format_gov_type,
-    geometry_to_mapping,
-    is_bbox_string,
-    is_geometry_mapping,
-    is_json,
-    json_to_semantic_html,
-    remove_html_tags,
-    simplify_resource_type,
-    usa_icon,
-)
 from .models import db
 from .utils import normalize_site_url
 
@@ -29,6 +15,13 @@ logger = logging.getLogger(__name__)
 load_dotenv()
 
 htmx = None
+
+
+def register_template_filters(app):
+    import app.filters as filters
+
+    for name in filters.__all__:
+        app.add_template_filter(getattr(filters, name))
 
 
 def create_app(config_name: str = "local") -> APIFlask:
@@ -73,18 +66,7 @@ def create_app(config_name: str = "local") -> APIFlask:
 
     register_commands(app)
 
-    app.add_template_filter(usa_icon)
-    app.add_template_filter(format_dcat_value)
-    app.add_template_filter(format_gov_type)
-    app.add_template_filter(fa_icon_from_extension)
-    app.add_template_filter(format_contact_point_email)
-    app.add_template_filter(is_bbox_string)
-    app.add_template_filter(is_geometry_mapping)
-    app.add_template_filter(geometry_to_mapping)
-    app.add_template_filter(remove_html_tags)
-    app.add_template_filter(simplify_resource_type)
-    app.add_template_filter(json_to_semantic_html)
-    app.add_template_filter(is_json)
+    register_template_filters(app)
 
     # Content-Security-Policy headers
     # single quotes need to appear in some of the strings

--- a/app/filters.py
+++ b/app/filters.py
@@ -233,6 +233,42 @@ def is_json(value):
         return False
 
 
+def dcatus_to_schema_org_jsonld(dcatus: dict):
+    """
+    converts dcatus into schema.org jsonld for google search compatibility
+
+    all inputs are valid dcatus
+    """
+
+    return {
+        "@context": "https://schema.org/",
+        "@type": "Dataset",
+        "name": dcatus.get("title"),  # required
+        "description": dcatus.get("description"),  # required
+        "url": dcatus.get("landingPage", None),
+        "identifier": dcatus.get("identifier"),  # required
+        "keywords": dcatus.get("keyword"),  # required
+        "license": dcatus.get("license", None),
+        "datePublished": dcatus.get("issued", None),
+        "dateModified": dcatus.get("modified"),  # required
+        "publisher": {
+            "@type": "Organization",
+            "name": dcatus.get("publisher").get("name"),  # required
+        },
+        "distribution": [
+            {
+                "@type": "DataDownload",
+                "encodingFormat": dist.get(
+                    "mediaType"
+                ),  # required when downloadURL is present
+                "contentUrl": dist.get("downloadURL"),
+            }
+            for dist in dcatus.get("distribution", [])
+            if dist.get("downloadURL")
+        ],
+    }
+
+
 __all__ = [
     "usa_icon",
     "format_dcat_value",
@@ -246,4 +282,5 @@ __all__ = [
     "simplify_resource_type",
     "json_to_semantic_html",
     "is_json",
+    "dcatus_to_schema_org_jsonld",
 ]

--- a/app/templates/dataset_detail.html
+++ b/app/templates/dataset_detail.html
@@ -37,7 +37,7 @@
 
 {% block gsearchdata %}
 <script type="application/ld+json">
-    {{ dataset.dcat | tojson }}
+    {{ dataset.dcat | dcatus_to_schema_org_jsonld | tojson }}
 </script>
 {% endblock %}
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -113,6 +113,9 @@ def fixture_data():
                     "title": "test",
                     "description": "this is the test description",
                     "keyword": ["health", "education", "Health"],
+                    "identifier": "test identifier",
+                    "modified": "2026-03-04",
+                    "publisher": {"name": "test publisher"},
                     "distribution": [
                         {
                             "title": "Test CSV",
@@ -169,6 +172,9 @@ def fixture_data():
                     "description": "Environmental monitoring and climate science datasets",
                     "keyword": ["environment", "science", "climate", "Environment"],
                     "spatial": "-122.4194,37.7749,-122.4094,37.7849",
+                    "identifier": "test climate environment",
+                    "modified": "2026-03-04",
+                    "publisher": {"name": "test publisher"},
                     "distribution": [
                         {
                             "title": "Climate Measurements",
@@ -254,6 +260,8 @@ def fixture_data():
                     "description": "National statistics on access to health food resources",
                     "keyword": ["health", "food"]
                     * 25,  # the tag/keyword section is collapsible in dataset_detail.html (max 8 tags)
+                    "modified": "2026-03-04",
+                    "publisher": {"name": "test parent publisher"},
                     "distribution": [
                         {
                             "title": "Health Food Data",
@@ -289,6 +297,8 @@ def fixture_data():
                     "title": "Child Harvest Record",
                     "description": "National statistics on access to health food resources",
                     "keyword": ["health", "food"],
+                    "modified": "2026-03-04",
+                    "publisher": {"name": "test child publisher"},
                     "distribution": [
                         {
                             "title": "Health Food Data",

--- a/tests/unit/test_dataset_detail.py
+++ b/tests/unit/test_dataset_detail.py
@@ -377,19 +377,24 @@ class TestDatasetDetail:
         )
 
         expected = {
-            "@type": "dcat:Dataset",
+            "@context": "https://schema.org/",
+            "@type": "Dataset",
+            "dateModified": "2026-03-04",
+            "datePublished": None,
             "description": "this is the test description",
             "distribution": [
                 {
-                    "description": "Sample CSV resource",
-                    "downloadURL": "https://example.com/test.csv",
-                    "format": "CSV",
-                    "mediaType": "text/csv",
-                    "title": "Test CSV",
+                    "@type": "DataDownload",
+                    "contentUrl": "https://example.com/test.csv",
+                    "encodingFormat": "text/csv",
                 }
             ],
-            "keyword": ["health", "education", "Health"],
-            "title": "test",
+            "identifier": "test identifier",
+            "keywords": ["health", "education", "Health"],
+            "license": None,
+            "name": "test",
+            "publisher": {"@type": "Organization", "name": "test publisher"},
+            "url": None,
         }
 
         assert jsonld == expected


### PR DESCRIPTION
related to [5863](https://github.com/GSA/data.gov/issues/5863)
- adds dcatus to schema.org json ld filter for dataset detail page
- simplifies template filter configuration

[dataset on dev](https://catalog-dev.data.gov/dataset/fima-nfip-redacted-claims-openfema) with changes.

google search rich results tester (dev is behind basic auth so can't use url checker. i copied the script element in the page and pasted it into this tool.

<img width="1558" height="669" alt="Screenshot 2026-05-06 at 12 39 18 PM" src="https://github.com/user-attachments/assets/75525a0a-52fb-4060-ab15-c684e8554699" />
