### PR TITLE
fix schema.org json-ld conversion

### DIFF
--- a/app/filters.py
+++ b/app/filters.py
@@ -264,6 +264,31 @@ def format_dcat_date(value: datetime | date | None) -> str | None:
     return None
 
 
+def jsonld_distributions(dcatus: dict):
+    """
+    processes schema.org json-ld distributions. schema.org distributions
+    only supports type 'DataDownload' so accessURL is skipped.
+    """
+    output = []
+
+    if not dcatus["distribution"]:
+        return output
+
+    for dist in dcatus["distribution"]:
+        if dist.get("downloadURL"):
+            output.append(
+                {
+                    "@type": "DataDownload",
+                    "encodingFormat": dist.get(
+                        "mediaType"
+                    ),  # required when downloadURL is present
+                    "contentUrl": dist.get("downloadURL"),
+                }
+            )
+
+    return output
+
+
 def dcatus_to_schema_org_jsonld(dcatus: dict):
     """
     converts dcatus into schema.org jsonld for google search compatibility
@@ -286,17 +311,7 @@ def dcatus_to_schema_org_jsonld(dcatus: dict):
             "@type": "Organization",
             "name": dcatus.get("publisher").get("name"),  # required
         },
-        "distribution": [
-            {
-                "@type": "DataDownload",
-                "encodingFormat": dist.get(
-                    "mediaType"
-                ),  # required when downloadURL is present
-                "contentUrl": dist.get("downloadURL"),
-            }
-            for dist in dcatus.get("distribution", [])
-            if dist.get("downloadURL")
-        ],
+        "distribution": jsonld_distributions(dcatus),
     }
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -311,3 +311,50 @@ def sample_top_organizations():
             "aliases": [],
         },
     ]
+
+
+@pytest.fixture
+def dcatus_dataset():
+    return {
+        "@type": "dcat:Dataset",
+        "theme": None,
+        "title": "Social Security Number Verification Service (SSNVS) - Data Exchange",
+        "issued": None,
+        "rights": "The data contained in this data exchange is restricted due to sensitivity and/or privacy issues.  If you would like more information on a data exchange with SSA please visit the following web site https://www.ssa.gov/dataexchange/.",
+        "keyword": [
+            "BSO",
+            "Business Services Online",
+            "EVS",
+            "NOVU",
+            "Numident Online Verification Utility",
+            "OSES",
+            "SSNVS",
+        ],
+        "license": "https://www.ssa.gov/data/Restricted-Public-Licensing-Information.html",
+        "spatial": "United States",
+        "isPartOf": None,
+        "language": None,
+        "modified": "2016-03-15",
+        "temporal": None,
+        "publisher": {"name": "Social Security Administration"},
+        "bureauCode": ["016:00"],
+        "conformsTo": None,
+        "identifier": "US-GOV-SSA-620",
+        "references": None,
+        "accessLevel": "restricted public",
+        "dataQuality": None,
+        "describedBy": None,
+        "description": "SSNVS is a service offered by SSA's Business Services Online (BSO). It is used by employers and certain third-party submitters to verify the accuracy of the names and SSNs of their employees for wage reporting purposes. With SSNVS users may verify up to 10 names and SSNs online for immediate results or upload batch files for overnight processing. SSNVS uses the Numident Online Verification Utility (NOVU) for the online requests and EVS for the batch requests. SSNVS is maintained by OSES and both NOVU and EVS are maintained in OEEAS DIVES Verification System Branch.",
+        "landingPage": None,
+        "programCode": ["016:000"],
+        "contactPoint": {
+            "fn": "Open Data",
+            "@type": "vcard:Contact",
+            "hasEmail": "mailto:Open.Data@ssa.gov",
+        },
+        "distribution": None,
+        "describedByType": None,
+        "systemOfRecords": None,
+        "accrualPeriodicity": "R/P1D",
+        "primaryITInvestmentUII": None,
+    }

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 import pytest
 
 from app.filters import (
+    dcatus_to_schema_org_jsonld,
     format_dcat_date,
     parse_datetime,
     remove_html_tags,
@@ -19,6 +20,54 @@ def test_remove_html_tags(html_tags_within_text):
 
 def test_lt_or_gt_not_removed():
     assert remove_html_tags("in x < 0, but also y > 0") == "in x < 0, but also y > 0"
+
+
+def test_dcatus_to_schema_org_jsonld(dcatus_dataset):
+    assert dcatus_to_schema_org_jsonld(dcatus_dataset) == {
+        "@context": "https://schema.org/",
+        "@type": "Dataset",
+        "name": "Social Security Number Verification Service (SSNVS) - Data Exchange",
+        "description": "SSNVS is a service offered by SSA's Business Services Online (BSO). It is used by employers and certain third-party submitters to verify the accuracy of the names and SSNs of their employees for wage reporting purposes. With SSNVS users may verify up to 10 names and SSNs online for immediate results or upload batch files for overnight processing. SSNVS uses the Numident Online Verification Utility (NOVU) for the online requests and EVS for the batch requests. SSNVS is maintained by OSES and both NOVU and EVS are maintained in OEEAS DIVES Verification System Branch.",
+        "url": None,
+        "identifier": "US-GOV-SSA-620",
+        "keywords": [
+            "BSO",
+            "Business Services Online",
+            "EVS",
+            "NOVU",
+            "Numident Online Verification Utility",
+            "OSES",
+            "SSNVS",
+        ],
+        "license": "https://www.ssa.gov/data/Restricted-Public-Licensing-Information.html",
+        "datePublished": None,
+        "dateModified": "2016-03-15",
+        "publisher": {
+            "@type": "Organization",
+            "name": "Social Security Administration",
+        },
+        "distribution": [],
+    }
+
+    dcatus_dataset["distribution"] = [
+        {
+            "@type": "dcat:Distribution",
+            "description": "This set of Excel files contains data on students reported as harassed or bullied or disciplined for harassment or bullying on the basis of sex, race, or disability category for all states. Each file contains three spreadsheets: total students, male students, and female students.",
+            "downloadURL": "https://civilrightsdata.ed.gov/assets/downloads/2017-2018/School-Climate/Harassment-or-Bullying/Harassment-Bullying-on-basis-of-disability_discplined.xlsx",
+            "format": "XLSX",
+            "mediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "title": "On basis of disability - disciplined",
+        }
+    ]
+
+    # only distribution has changed so no need to check anything other than that
+    assert dcatus_to_schema_org_jsonld(dcatus_dataset)["distribution"] == [
+        {
+            "@type": "DataDownload",
+            "encodingFormat": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "contentUrl": "https://civilrightsdata.ed.gov/assets/downloads/2017-2018/School-Climate/Harassment-or-Bullying/Harassment-Bullying-on-basis-of-disability_discplined.xlsx",
+        }
+    ]
 
 
 class TestSimplifyResourceType:
@@ -44,7 +93,6 @@ class TestSimplifyResourceType:
 
 
 class TestParseDatetime:
-
     def test_date_only_string_returns_date(self):
         result = parse_datetime("2026-05-01")
         assert type(result) is date
@@ -65,7 +113,6 @@ class TestParseDatetime:
 
 
 class TestFormatDcatDate:
-
     @pytest.mark.parametrize(
         "raw, expected",
         [


### PR DESCRIPTION
related to 5960](https://github.com/GSA/data.gov/issues/5960)

the cause of the 500 is because that dataset has `"distribution": None` and we're trying to iterate over that which you can't do.