### PR TITLE
Add explicit workflow token permissions

### DIFF
--- a/.github/workflows/check-db-models.yml
+++ b/.github/workflows/check-db-models.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   check-sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add an explicit `permissions` block to `.github/workflows/check-db-models.yml`.
- Set `contents: read` as the minimal `GITHUB_TOKEN` scope.

## Why
Code scanning flags workflows without explicit token scopes. Declaring least-privilege permissions improves security posture and documents required access.