### PR TITLE
add ispartof count

### DIFF
--- a/app/api_schemas.py
+++ b/app/api_schemas.py
@@ -185,6 +185,7 @@ class StatsMetrics(Schema):
 
 class StatsResults(Schema):
     datasets = Integer()
+    datasetsWithIsPartOf = Integer()
 
 
 class StatsResult(Schema):

--- a/app/database/interface.py
+++ b/app/database/interface.py
@@ -487,6 +487,12 @@ class CatalogDBInterface:
         """
         return self.opensearch.count_all_datasets()
 
+    def count_datasets_with_ispartof_in_search(self) -> int:
+        """
+        Get the total number of indexed datasets with a DCAT isPartOf value.
+        """
+        return self.opensearch.count_datasets_with_ispartof()
+
     @staticmethod
     def _normalize_metric_count(number: int) -> float:
         """feed the data the way 11ty chart wants it (log-scaled)"""
@@ -508,6 +514,7 @@ class CatalogDBInterface:
         work is performed only when `/api/stats` is called.
         """
         total_datasets = self.count_all_datasets_in_search()
+        datasets_with_ispartof = self.count_datasets_with_ispartof_in_search()
         harvest_stats = self.opensearch.get_last_harvested_stats()
         counts_by_slug = self.get_opensearch_org_dataset_counts(as_dict=True)
         harvest_sources_by_org_id = dict(
@@ -560,6 +567,7 @@ class CatalogDBInterface:
         return {
             "results": {
                 "datasets": total_datasets,
+                "datasetsWithIsPartOf": datasets_with_ispartof,
             },
             "metrics": {
                 "orgBarMetric": self._encode_metric_payload(org_metric_rows),

--- a/app/database/opensearch.py
+++ b/app/database/opensearch.py
@@ -1306,3 +1306,24 @@ class OpenSearchInterface:
         except Exception as e:
             logger.error(f"Error counting datasets in OpenSearch: {e}")
             return 0
+
+    def count_datasets_with_ispartof(self) -> int:
+        """
+        Get the total count of datasets whose DCAT payload includes isPartOf.
+        """
+        try:
+            result = self.client.count(
+                index=self.INDEX_NAME,
+                body={
+                    "query": {
+                        "nested": {
+                            "path": "dcat",
+                            "query": {"exists": {"field": "dcat.isPartOf"}},
+                        }
+                    }
+                },
+            )
+            return result.get("count", 0)
+        except Exception as e:
+            logger.error(f"Error counting datasets with isPartOf in OpenSearch: {e}")
+            return 0

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -450,7 +450,8 @@ class TestOpenSearchMappings:
         assert mappings["properties"]["spatial_centroid"]["type"] == "geo_point"
 
 
-def test_count_datasets_with_ispartof_uses_nested_exists_query():
+def test_count_datasets_with_ispartof_passes_filtered_count_query():
+    """OpenSearch count returns the number of docs matching the supplied query."""
     client = OpenSearchInterface.__new__(OpenSearchInterface)
     client.INDEX_NAME = "datasets"
     client.client = Mock()

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -450,6 +450,28 @@ class TestOpenSearchMappings:
         assert mappings["properties"]["spatial_centroid"]["type"] == "geo_point"
 
 
+def test_count_datasets_with_ispartof_uses_nested_exists_query():
+    client = OpenSearchInterface.__new__(OpenSearchInterface)
+    client.INDEX_NAME = "datasets"
+    client.client = Mock()
+    client.client.count.return_value = {"count": 7}
+
+    count = client.count_datasets_with_ispartof()
+
+    assert count == 7
+    client.client.count.assert_called_once_with(
+        index=client.INDEX_NAME,
+        body={
+            "query": {
+                "nested": {
+                    "path": "dcat",
+                    "query": {"exists": {"field": "dcat.isPartOf"}},
+                }
+            }
+        },
+    )
+
+
 class TestCaseInsensitiveKeywords:
     """
     Tests for case-insensitive keyword filtering and aggregation.

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -324,7 +324,7 @@ def test_get_opensearch_health_api_handles_errors(db_client):
 def test_get_stats_api_returns_data(db_client):
     mock_interface = Mock()
     mock_interface.get_stats.return_value = {
-        "results": {"datasets": 123456},
+        "results": {"datasets": 123456, "datasetsWithIsPartOf": 789},
         "metrics": {"orgBarMetric": "%5B%5D", "datasetsBarMetric": "%5B%5D"},
         "meta": {"date": "Thu, 01 Jan 2026 00:00:00 GMT"},
     }
@@ -335,6 +335,7 @@ def test_get_stats_api_returns_data(db_client):
     assert response.status_code == 200
     data = response.get_json()
     assert data["results"]["datasets"] == 123456
+    assert data["results"]["datasetsWithIsPartOf"] == 789
     mock_interface.get_stats.assert_called_once_with()
 
 


### PR DESCRIPTION
- https://github.com/GSA/data.gov/issues/5682

We need this info in the /api/stats for the chart:

<img width="535" height="306" alt="Image" src="https://github.com/user-attachments/assets/76f01626-eb78-434e-b2cb-e9a82a8bc8a6" />

# About
Add collection dataset count into /api/stats. It is good for now. All features related to isPartOf on catalog is not fully implemented yet, in the future we might have better way to get the collection child (datasetsWithIsPartOf) dataset count. We will change when the time comes.




