### PR TITLE
Pre-commit hook for linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,10 @@
-# Runs the same linters/formatters as `make lint-check`, scoped to staged files, before each commit.
-# One-time setup per clone:  pip install pre-commit && pre-commit install
-# Tool versions are kept in sync with the pins in poetry.lock / pyproject.toml.
+# Runs the repository's existing lint/format pipeline before each commit.
+# One-time setup per clone: pip install pre-commit && pre-commit install
 repos:
-  - repo: https://github.com/psf/black
-    rev: 26.5.1
+  - repo: local
     hooks:
-      - id: black
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.14
-    hooks:
-      - id: ruff-check
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 8.0.1
-    hooks:
-      - id: isort
+      - id: lint-fix
+        name: make lint-fix
+        entry: make lint-fix
+        language: system
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ poetry-plugin-export = ">=1.10"
 
 [tool.isort]
 profile = "black"
-skip = [".poetry", "app/static/node_modules"]
+skip = [".poetry", "app/static/node_modules", ".venv"]
 
 [tool.black]
 target-version = ["py312"]


### PR DESCRIPTION
I think this will be cleaner. This should fix the linting using the makefile best practices, so it remains the same process. Installing the repo's seems unnecessary, as if you've run `poetry install` the libraries are all there.