### PR TITLE
Static Asset Cache Busting

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -88,11 +88,15 @@ runs:
       shell: bash
       run: make update-dependencies && cat requirements.txt
 
+    - name: Set deploy asset version
+      shell: bash
+      run: echo "asset_version=${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
+
     - name: Deploy datagov-catalog app
       uses: cloud-gov/cg-cli-tools@main
       with:
         command: >-
-          ${{ inputs.command }} --vars-file vars.${{ inputs.cf_space }}.yml
+          ${{ inputs.command }} --vars-file vars.${{ inputs.cf_space }}.yml --var asset_version=${{ env.asset_version }}
         cf_org: ${{ inputs.cf_org }}
         cf_space: ${{ inputs.cf_space }}
         cf_username: ${{ inputs.cf_username }}

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,6 +20,7 @@ htmx = None
 
 def register_template_filters(app):
     import app.filters as filters
+
     from .static_assets import static_url
 
     for name in filters.__all__:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,9 +20,12 @@ htmx = None
 
 def register_template_filters(app):
     import app.filters as filters
+    from .static_assets import static_url
 
     for name in filters.__all__:
         app.add_template_filter(getattr(filters, name))
+
+    app.add_template_global(static_url, "static_url")
 
 
 def create_app(config_name: str = "local") -> APIFlask:
@@ -36,7 +39,10 @@ def create_app(config_name: str = "local") -> APIFlask:
     if os.getenv("SITE_URL"):
         app.config["SERVERS"] = [{"url": f"{os.getenv('SITE_URL')}"}]
 
+    from .static_assets import get_asset_version
+
     app.config["PREFERRED_URL_SCHEME"] = "https"
+    app.config["ASSET_VERSION"] = get_asset_version()
     # enable template hot template reloading in local
     if config_name == "local" or app.config.get("FLASK_ENV") == "local":
         # Enable template auto-reload

--- a/app/filters.py
+++ b/app/filters.py
@@ -8,7 +8,7 @@ from datetime import date, datetime
 from typing import Any, Union
 
 from bs4 import BeautifulSoup
-from flask import url_for
+from app.static_assets import static_url
 
 from shared.constants import ORGANIZATION_TYPE_VALUES
 
@@ -16,7 +16,7 @@ from shared.constants import ORGANIZATION_TYPE_VALUES
 def usa_icon(icon_name: str) -> str:
     """Return SVG markup for a USWDS icon referenced from the sprite sheet."""
 
-    sprite_path = url_for("static", filename="assets/uswds/img/sprite.svg")
+    sprite_path = static_url("assets/uswds/img/sprite.svg")
     return (
         '<svg class="usa-icon" aria-hidden="true" role="img">'
         f'<use xlink:href="{sprite_path}#{icon_name}"></use>'

--- a/app/filters.py
+++ b/app/filters.py
@@ -8,8 +8,8 @@ from datetime import date, datetime
 from typing import Any, Union
 
 from bs4 import BeautifulSoup
-from app.static_assets import static_url
 
+from app.static_assets import static_url
 from shared.constants import ORGANIZATION_TYPE_VALUES
 
 

--- a/app/static_assets.py
+++ b/app/static_assets.py
@@ -1,0 +1,41 @@
+"""Helpers for versioned static asset URLs."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from urllib.parse import urlencode
+
+from flask import current_app, url_for
+
+DEFAULT_ASSET_VERSION = "dev"
+
+
+def get_asset_version() -> str:
+    """Return the cache-bust version for static assets."""
+    env_version = os.getenv("ASSET_VERSION", "").strip()
+    if env_version:
+        return env_version
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short=7", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=2,
+        )
+        version = result.stdout.strip()
+        if version:
+            return version
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+    return DEFAULT_ASSET_VERSION
+
+
+def static_url(filename: str) -> str:
+    """Return a static asset URL with a cache-bust query parameter."""
+    version = current_app.config.get("ASSET_VERSION", DEFAULT_ASSET_VERSION)
+    base_url = url_for("static", filename=filename)
+    return f"{base_url}?{urlencode({'v': version})}"

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,12 +12,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Catalog - Data.gov{% endblock %}</title>
   {% block head_extra %}{% endblock %}
-  <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='assets/img/favicon.ico') }}">
-  <link rel="stylesheet" href="{{ url_for('static', filename='assets/uswds/css/styles.css') }}">
+  <link rel="icon" type="image/x-icon" href="{{ static_url('assets/img/favicon.ico') }}">
+  <link rel="stylesheet" href="{{ static_url('assets/uswds/css/styles.css') }}">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
-  <script src="{{ url_for('static', filename='assets/uswds/js/uswds-init.js') }}"></script>
-  <script src="{{ url_for('static', filename='assets/htmx/htmx.min.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/datetime.js') }}"></script>
+  <script src="{{ static_url('assets/uswds/js/uswds-init.js') }}"></script>
+  <script src="{{ static_url('assets/htmx/htmx.min.js') }}"></script>
+  <script src="{{ static_url('js/datetime.js') }}"></script>
   <!-- zendesk -->
   <script id="ze-snippet"
     src="https://static.zdassets.com/ekr/snippet.js?key=d9b8cbcb-4275-46af-a445-49ce9c4a22c0"></script>
@@ -48,8 +48,8 @@
 
   {% include "components/footer.html" %}
 
-  <script src="{{ url_for('static', filename='assets/uswds/js/uswds.js') }}"></script>
-  <script src="{{ url_for('static', filename='assets/js/bundle.js') }}"></script>
+  <script src="{{ static_url('assets/uswds/js/uswds.js') }}"></script>
+  <script src="{{ static_url('assets/js/bundle.js') }}"></script>
   <!-- Load the GitHub buttons script -->
   <script async defer src="https://buttons.github.io/buttons.js"></script>
   {% block scripts %}{% endblock %}

--- a/app/templates/components/header.html
+++ b/app/templates/components/header.html
@@ -3,7 +3,7 @@
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <img class="usa-banner__header-flag" src="{{ url_for('static', filename='assets/uswds/img/us_flag_small.png') }}"
+          <img class="usa-banner__header-flag" src="{{ static_url('assets/uswds/img/us_flag_small.png') }}"
             alt="U.S. flag">
         </div>
         <div class="grid-col-fill tablet:grid-col-auto">
@@ -20,7 +20,7 @@
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img"
-            src="{{ url_for('static', filename='assets/uswds/img/icon-dot-gov.svg') }}"
+            src="{{ static_url('assets/uswds/img/icon-dot-gov.svg') }}"
             role="img" alt="Dot gov">
           <div class="usa-media-block__body">
             <p>
@@ -32,7 +32,7 @@
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img"
-            src="{{ url_for('static', filename='assets/uswds/img/icon-https.svg') }}"
+            src="{{ static_url('assets/uswds/img/icon-https.svg') }}"
             role="img" alt="Https">
           <div class="usa-media-block__body">
             <p>

--- a/app/templates/components/navigation.html
+++ b/app/templates/components/navigation.html
@@ -9,7 +9,7 @@
     </div>
     <nav aria-label="Primary navigation" class="usa-nav">
       <button class="usa-nav__close" type="button">
-        <img src="{{ url_for('static', filename='assets/uswds/img/usa-icons/close.svg') }}" role="img" alt="Close">
+        <img src="{{ static_url('assets/uswds/img/usa-icons/close.svg') }}" role="img" alt="Close">
       </button>
       <ul class="usa-nav__primary usa-accordion">
         <li class="usa-nav__primary-item">

--- a/app/templates/dataset_detail.html
+++ b/app/templates/dataset_detail.html
@@ -432,11 +432,11 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/dataset_tags.js') }}"></script>
+<script src="{{ static_url('js/dataset_tags.js') }}"></script>
 {% if dataset.translated_spatial %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/vendor/leaflet.css') }}" />
-<script src="{{ url_for('static', filename='js/vendor/leaflet.js') }}"></script>
-<script src="{{ url_for('static', filename='js/view_bbox_map.js') }}"></script>
+<link rel="stylesheet" href="{{ static_url('css/vendor/leaflet.css') }}" />
+<script src="{{ static_url('js/vendor/leaflet.js') }}"></script>
+<script src="{{ static_url('js/view_bbox_map.js') }}"></script>
 </script>
 {% endif %}
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -185,9 +185,9 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/filter_form_auto_submit.js') }}"></script>
-<script src="{{ url_for('static', filename='js/filters_autocomplete.js') }}"></script>
-<script src="{{ url_for('static', filename='js/geography_autocomplete.js') }}"></script>
-<link rel="stylesheet" href="{{ url_for('static', filename='css/vendor/leaflet.css') }}"/>
-<script src="{{ url_for('static', filename='js/vendor/leaflet.js') }}"></script>
+<script src="{{ static_url('js/filter_form_auto_submit.js') }}"></script>
+<script src="{{ static_url('js/filters_autocomplete.js') }}"></script>
+<script src="{{ static_url('js/geography_autocomplete.js') }}"></script>
+<link rel="stylesheet" href="{{ static_url('css/vendor/leaflet.css') }}"/>
+<script src="{{ static_url('js/vendor/leaflet.js') }}"></script>
 {% endblock %}

--- a/app/templates/organization_detail.html
+++ b/app/templates/organization_detail.html
@@ -155,11 +155,11 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/filter_form_auto_submit.js') }}"></script>
-<script src="{{ url_for('static', filename='js/filters_autocomplete.js') }}"></script>
-<script src="{{ url_for('static', filename='js/geography_autocomplete.js') }}"></script>
-<link rel="stylesheet" href="{{ url_for('static', filename='css/vendor/leaflet.css') }}"/>
-<script src="{{ url_for('static', filename='js/vendor/leaflet.js') }}"></script>
+<script src="{{ static_url('js/filter_form_auto_submit.js') }}"></script>
+<script src="{{ static_url('js/filters_autocomplete.js') }}"></script>
+<script src="{{ static_url('js/geography_autocomplete.js') }}"></script>
+<link rel="stylesheet" href="{{ static_url('css/vendor/leaflet.css') }}"/>
+<script src="{{ static_url('js/vendor/leaflet.js') }}"></script>
 {% endblock %}
 
 {% block head_extra %}

--- a/manifest.yml
+++ b/manifest.yml
@@ -39,4 +39,5 @@ applications:
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
       NEW_RELIC_CONFIG_FILE: /home/vcap/app/config/newrelic.ini
       SITE_URL: ((site_url))
+      ASSET_VERSION: ((asset_version))
     command: ./app-start.sh

--- a/tests/unit/test_static_assets.py
+++ b/tests/unit/test_static_assets.py
@@ -1,0 +1,40 @@
+from unittest.mock import Mock
+
+from app.static_assets import DEFAULT_ASSET_VERSION, get_asset_version, static_url
+
+
+def test_get_asset_version_uses_env_var(monkeypatch):
+    monkeypatch.setenv("ASSET_VERSION", "abc1234")
+    assert get_asset_version() == "abc1234"
+
+
+def test_get_asset_version_falls_back_to_dev_when_git_unavailable(monkeypatch):
+    monkeypatch.delenv("ASSET_VERSION", raising=False)
+
+    def fail_git(*args, **kwargs):
+        raise OSError("git not found")
+
+    monkeypatch.setattr("app.static_assets.subprocess.run", fail_git)
+    assert get_asset_version() == DEFAULT_ASSET_VERSION
+
+
+def test_get_asset_version_uses_git_when_env_unset(monkeypatch):
+    monkeypatch.delenv("ASSET_VERSION", raising=False)
+    monkeypatch.setattr(
+        "app.static_assets.subprocess.run",
+        Mock(
+            return_value=Mock(
+                stdout="8eb9d3e\n",
+            )
+        ),
+    )
+    assert get_asset_version() == "8eb9d3e"
+
+
+def test_static_url_appends_version_query(app):
+    app.config["ASSET_VERSION"] = "8eb9d3e"
+    with app.test_request_context("/"):
+        url = static_url("js/filter_sidebar_toggle.js")
+
+    assert url.endswith("?v=8eb9d3e")
+    assert "/js/filter_sidebar_toggle.js" in url

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -10,3 +10,4 @@ basic_auth_enabled: on # nginx terminology 'on' 'off'. cf will interpret these a
 route_external: catalog-dev.data.gov
 route_beta: catalog-beta-dev.app.cloud.gov # an invalid url because there's no 'beta' equivalent
 route_internal: datagov-catalog-dev.apps.internal
+asset_version: dev

--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -10,3 +10,4 @@ basic_auth_enabled: off # nginx terminology 'on' 'off'. cf will interpret these 
 route_external: catalog.data.gov
 route_beta: catalog-beta.data.gov  
 route_internal: datagov-catalog-prod.apps.internal
+asset_version: dev

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -10,3 +10,4 @@ basic_auth_enabled: on # nginx terminology 'on' 'off'. cf will interpret these a
 route_external: catalog-stage.data.gov
 route_beta: unused-staging-redirect.invalid # an invalid url because there's no 'beta' equivalent
 route_internal: datagov-catalog-staging.apps.internal
+asset_version: dev


### PR DESCRIPTION
adding a static asset version using GITHUB_SHA during the build so that new deployments will properly fetch the latest version of the assets associated with that build.  This is to prevent potential stale cache issues on cloudfront on new deployments.