### PR TITLE
Changing the HTML SVG

### DIFF
--- a/app/filters.py
+++ b/app/filters.py
@@ -133,16 +133,77 @@ def format_icon_class(extension: str) -> str:
     return f"file-icon--{icon}"
 
 
+_OVERLAY_BADGE_MAX_LEN = 4
+
+# Short badge labels for normalized formats that are too long for the icon overlay.
+_OVERLAY_BADGE_ALIASES = {
+    "octet-stream": "BIN",
+    "arcgis geoservices rest api": "REST",
+}
+
+
+def _shorten_overlay_label(label: str) -> str:
+    if len(label) <= _OVERLAY_BADGE_MAX_LEN:
+        return label
+
+    return label[:_OVERLAY_BADGE_MAX_LEN]
+
+
+def _extract_badge_source(normalized: str) -> str:
+    source = normalized
+    if source.startswith("vnd."):
+        source = source[4:]
+    if source.startswith("x-"):
+        source = source[2:]
+
+    if "." in source:
+        source = source.rsplit(".", 1)[-1]
+
+    source = source.split("+", 1)[0]
+    source = source.split("-", 1)[0]
+    source = source.split()[0] if source.split() else source
+
+    return re.sub(r"[^a-z0-9]", "", source.lower())
+
+
+def _badge_label_from_normalized(normalized: str) -> str:
+    if normalized in _OVERLAY_BADGE_ALIASES:
+        return _OVERLAY_BADGE_ALIASES[normalized]
+
+    source = _extract_badge_source(normalized)
+    if not source:
+        return "FILE"
+
+    return _shorten_overlay_label(source.upper())
+
+
 def format_overlay_label(extension: str) -> str:
     """Short badge text overlaid on the default file icon for formats we don't
     have a dedicated icon for (e.g. KML, WMS, WFS, GML). Returns "" when a
     dedicated icon is available."""
+    if not isinstance(extension, str):
+        return ""
+
     normalized = _normalize_format(extension)
     if normalized in _FORMAT_ICON_MAP:
         return ""
     if normalized in ("default", "file", ""):
         return ""
-    return normalized.upper()
+    return _badge_label_from_normalized(normalized)
+
+
+def format_icon_label(extension: str) -> str:
+    """Return a short extension label for inline file icons, or "" for static SVG icons."""
+    if not isinstance(extension, str):
+        return ""
+
+    normalized = _normalize_format(extension)
+    icon = _FORMAT_ICON_MAP.get(normalized, "default")
+    if icon == "html":
+        return "HTML"
+    if icon != "default":
+        return ""
+    return format_overlay_label(extension)
 
 
 def format_contact_point_email(email: str) -> Union[str, None]:
@@ -393,6 +454,7 @@ __all__ = [
     "is_geometry_mapping",
     "geometry_to_mapping",
     "format_icon_class",
+    "format_icon_label",
     "format_overlay_label",
     "format_contact_point_email",
     "remove_html_tags",

--- a/app/routes.py
+++ b/app/routes.py
@@ -1083,27 +1083,126 @@ def openapi_docs():
 
 
 def style_guide_icons():
-    samples = [
-        {"format": "CSV", "label": "Sample data export"},
-        {"format": "application/json", "label": "DCAT-US metadata"},
-        {"format": "application/xml", "label": "FGDC metadata record"},
-        {"format": "application/rdf+xml", "label": "Linked-data manifest"},
-        {"format": "PDF", "label": "Codebook"},
-        {"format": "ZIP", "label": "Bulk archive"},
-        {"format": "XLSX", "label": "Quarterly workbook"},
-        {"format": "DOCX", "label": "Methodology document"},
-        {"format": "HTML", "label": "Project landing page"},
-        {"format": "TXT", "label": "Readme"},
-        {"format": "application/geo+json", "label": "Boundaries (GeoJSON)"},
-        {"format": "PNG", "label": "Map preview"},
-        {"format": "API", "label": "REST endpoint"},
-        {"format": "KML", "label": "Aerial overlay (KML)"},
-        {"format": "WMS", "label": "Web Map Service"},
-        {"format": "WFS", "label": "Web Feature Service"},
-        {"format": "GML", "label": "Geography Markup"},
-        {"format": "SHP", "label": "Shapefile (no icon)"},
+    sample_sections = [
+        {
+            "title": "Dedicated icons",
+            "description": (
+                "Formats with a matching SVG render the file-type icon with no badge."
+            ),
+            "samples": [
+                {"format": "CSV", "label": "Sample data export"},
+                {"format": "application/json", "label": "DCAT-US metadata"},
+                {"format": "application/xml", "label": "FGDC metadata record"},
+                {"format": "application/rdf+xml", "label": "Linked-data manifest"},
+                {"format": "PDF", "label": "Codebook"},
+                {"format": "ZIP", "label": "Bulk archive"},
+                {"format": "XLSX", "label": "Quarterly workbook"},
+                {"format": "DOCX", "label": "Methodology document"},
+                {"format": "HTML", "label": "Project landing page"},
+                {"format": "TXT", "label": "Readme"},
+                {"format": "application/geo+json", "label": "Boundaries (GeoJSON)"},
+                {"format": "PNG", "label": "Map preview"},
+                {"format": "API", "label": "REST endpoint"},
+            ],
+        },
+        {
+            "title": "Short badge overlays",
+            "description": (
+                "Unrecognized formats use the shared file outline with a short "
+                "extension label rendered as SVG text."
+            ),
+            "samples": [
+                {"format": "KML", "label": "Aerial overlay (KML)"},
+                {"format": "WMS", "label": "Web Map Service"},
+                {"format": "WFS", "label": "Web Feature Service"},
+                {"format": "GML", "label": "Geography Markup"},
+                {"format": "SHP", "label": "Shapefile"},
+                {
+                    "format": "application/vnd.google-earth.kml+xml",
+                    "label": "KML (vendor MIME)",
+                },
+                {"format": "application/vnd.ogc.wms", "label": "WMS (vendor MIME)"},
+            ],
+        },
+        {
+            "title": "Long formats (truncated badges & subtitles)",
+            "description": (
+                "Long MIME types and extension strings truncate in the format "
+                "subtitle. Hover to see the full value."
+            ),
+            "samples": [
+                {
+                    "format": "application/octet-stream",
+                    "label": "Binary download (octet-stream)",
+                },
+                {
+                    "format": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "label": "Excel workbook (long vendor MIME)",
+                },
+                {
+                    "format": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    "label": "Word document (long vendor MIME)",
+                },
+                {
+                    "format": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                    "label": "PowerPoint deck (long vendor MIME)",
+                },
+                {
+                    "format": "application/vnd.unknown-format",
+                    "label": "Unknown vendor format",
+                },
+                {
+                    "format": "application/vnd.esri.mapserver",
+                    "label": "Esri MapServer endpoint",
+                },
+                {
+                    "format": "ARCGIS GEOSERVICES REST API",
+                    "label": "ArcGIS GeoService",
+                },
+                {
+                    "format": "application/vnd.mapbox-vector-tile",
+                    "label": "Mapbox vector tiles",
+                },
+                {
+                    "format": "application/x-netcdf",
+                    "label": "NetCDF scientific dataset",
+                },
+                {
+                    "format": "application/x-protobuf",
+                    "label": "Protocol buffer payload",
+                },
+                {
+                    "format": "application/x-msdownload",
+                    "label": "Windows executable download",
+                },
+                {
+                    "format": "application/x-zip-compressed",
+                    "label": "ZIP archive (x-zip-compressed)",
+                },
+                {
+                    "format": "text/tab-separated-values",
+                    "label": "Tab-separated values export",
+                },
+                {
+                    "format": "application/vnd.geo+json",
+                    "label": "GeoJSON (vendor geo+json MIME)",
+                },
+                {
+                    "format": "application/vnd.sqlite3",
+                    "label": "SQLite database file",
+                },
+                {
+                    "format": "model/vnd.collada+xml",
+                    "label": "COLLADA 3D model",
+                },
+                {
+                    "format": "verylongformatnamewithouticon",
+                    "label": "Extremely long plain format string",
+                },
+            ],
+        },
     ]
-    return render_template("style_guide_icons.html", samples=samples)
+    return render_template("style_guide_icons.html", sample_sections=sample_sections)
 
 
 def register_routes(app):

--- a/app/static/_scss/_uswds-theme-custom-styles.scss
+++ b/app/static/_scss/_uswds-theme-custom-styles.scss
@@ -745,6 +745,7 @@ details {
     bottom: -2px;
     right: -2px;
     min-width: 16px;
+    max-width: 24px;
     height: 12px;
     padding: 0 3px;
     border-radius: 2px;
@@ -755,6 +756,9 @@ details {
     line-height: 12px;
     text-align: center;
     letter-spacing: 0.02em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .resources-list__details {
@@ -777,6 +781,9 @@ details {
     color: #62676A;
     text-transform: uppercase;
     margin-top: 0.125rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .resources-list__link {
@@ -838,6 +845,7 @@ details {
         bottom: 0;
         right: 0;
         min-width: 22px;
+        max-width: 32px;
         height: 14px;
         padding: 0 4px;
         border-radius: 3px;
@@ -845,6 +853,9 @@ details {
         line-height: 14px;
         background: #e8f0fe;
         color: #1a4480;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 }
 
@@ -865,6 +876,9 @@ details {
     text-transform: uppercase;
     letter-spacing: 0.04em;
     margin-top: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .resources-list__actions {

--- a/app/static/_scss/components/_file_icon.scss
+++ b/app/static/_scss/components/_file_icon.scss
@@ -7,6 +7,13 @@
     background-size: contain;
 }
 
+.file-icon--labeled {
+    display: inline-block;
+    width: 100%;
+    height: 100%;
+    color: #000;
+}
+
 .file-icon--csv     { background-image: url("../../img/file-icons/csv.svg"); }
 .file-icon--json    { background-image: url("../../img/file-icons/json.svg"); }
 .file-icon--xml     { background-image: url("../../img/file-icons/xml.svg"); }

--- a/app/static/_scss/components/_style_guide.scss
+++ b/app/static/_scss/components/_style_guide.scss
@@ -1,8 +1,28 @@
+.style-guide-section {
+    margin-top: 2.5rem;
+
+    &:first-of-type {
+        margin-top: 0;
+    }
+}
+
+.style-guide-section__title {
+    font-size: 1.25rem;
+    margin: 0 0 0.5rem;
+    color: #1b1b1b;
+}
+
+.style-guide-section__description {
+    margin: 0 0 1rem;
+    color: #62676a;
+    max-width: 70ch;
+}
+
 .style-guide-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 1rem;
-    margin-top: 2rem;
+    margin-top: 0;
 }
 
 @media (max-width: 880px) {

--- a/app/static/assets/img/file-icons/ATTRIBUTIONS.md
+++ b/app/static/assets/img/file-icons/ATTRIBUTIONS.md
@@ -13,7 +13,8 @@ each upstream license is included in the [`licenses/`](./licenses) directory.
 | `zip.svg` | VSCode Icons | MIT | [`licenses/vscode-icons.LICENSE`](./licenses/vscode-icons.LICENSE) | https://github.com/vscode-icons/vscode-icons | `vscode-icons:file-type-zip` |
 | `excel.svg` | VSCode Icons | MIT | [`licenses/vscode-icons.LICENSE`](./licenses/vscode-icons.LICENSE) | https://github.com/vscode-icons/vscode-icons | `vscode-icons:file-type-excel` |
 | `word.svg` | VSCode Icons | MIT | [`licenses/vscode-icons.LICENSE`](./licenses/vscode-icons.LICENSE) | https://github.com/vscode-icons/vscode-icons | `vscode-icons:file-type-word` |
-| `html.svg` | VSCode Icons | MIT | [`licenses/vscode-icons.LICENSE`](./licenses/vscode-icons.LICENSE) | https://github.com/vscode-icons/vscode-icons | `vscode-icons:file-type-html` |
+| `html.svg` | Phosphor Icons | MIT | [`licenses/phosphor-icons.LICENSE`](./licenses/phosphor-icons.LICENSE) | https://phosphoricons.com/ | `ph:file-html-light` (file base + `HTML` text) |
+| `file-base.svg` | Phosphor Icons | MIT | [`licenses/phosphor-icons.LICENSE`](./licenses/phosphor-icons.LICENSE) | https://phosphoricons.com/ | `ph:file-html-light` (file outline only) |
 | `geojson.svg` | VSCode Icons | MIT | [`licenses/vscode-icons.LICENSE`](./licenses/vscode-icons.LICENSE) | https://github.com/vscode-icons/vscode-icons | `vscode-icons:file-type-geojson` |
 | `image.svg` | VSCode Icons | MIT | [`licenses/vscode-icons.LICENSE`](./licenses/vscode-icons.LICENSE) | https://github.com/vscode-icons/vscode-icons | `vscode-icons:file-type-image` |
 | `text.svg` | VSCode Icons | MIT | [`licenses/vscode-icons.LICENSE`](./licenses/vscode-icons.LICENSE) | https://github.com/vscode-icons/vscode-icons | `vscode-icons:file-type-text` |
@@ -34,6 +35,8 @@ upstream license, taken from the source repositories:
   — MIT, from https://github.com/catppuccin/vscode-icons
 - [`vscode-icons.LICENSE`](./licenses/vscode-icons.LICENSE)
   — MIT, from https://github.com/vscode-icons/vscode-icons
+- [`phosphor-icons.LICENSE`](./licenses/phosphor-icons.LICENSE)
+  — MIT, from https://phosphoricons.com/ (source: https://github.com/phosphor-icons/core)
 - [`material-design-icons.LICENSE`](./licenses/material-design-icons.LICENSE)
   — Pictogrammers Free License (icons released under Apache-2.0), from
   https://github.com/Templarian/MaterialDesign

--- a/app/static/assets/img/file-icons/file-base.svg
+++ b/app/static/assets/img/file-icons/file-base.svg
@@ -1,5 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 256 256">
   <path d="M0 0h256v256H0z" fill="none" />
   <path fill="#000" d="M214 120V88a6 6 0 0 0-1.76-4.24l-56-56A6 6 0 0 0 152 26H56a14 14 0 0 0-14 14v80a6 6 0 0 0 12 0V40a2 2 0 0 1 2-2h90v50a6 6 0 0 0 6 6h50v26a6 6 0 0 0 12 0m-56-73.52L193.52 82H158Z" />
-  <text x="128" y="204" text-anchor="middle" dominant-baseline="middle" font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-weight="700" font-size="56" fill="#000">HTML</text>
 </svg>

--- a/app/static/assets/img/file-icons/licenses/phosphor-icons.LICENSE
+++ b/app/static/assets/img/file-icons/licenses/phosphor-icons.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Phosphor Icons
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/templates/components/labeled_file_icon.html
+++ b/app/templates/components/labeled_file_icon.html
@@ -1,0 +1,7 @@
+{% macro labeled_file_icon(label, title=none) %}
+{% set font_size = 64 if label|length <= 3 else (56 if label|length == 4 else 48) %}
+<svg class="file-icon file-icon--labeled" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"{% if title %} title="{{ title }}"{% endif %} aria-hidden="true">
+  <path fill="#000" d="M214 120V88a6 6 0 0 0-1.76-4.24l-56-56A6 6 0 0 0 152 26H56a14 14 0 0 0-14 14v80a6 6 0 0 0 12 0V40a2 2 0 0 1 2-2h90v50a6 6 0 0 0 6 6h50v26a6 6 0 0 0 12 0m-56-73.52L193.52 82H158Z" />
+  <text x="128" y="204" text-anchor="middle" dominant-baseline="middle" font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-weight="700" font-size="{{ font_size }}" fill="#000">{{ label }}</text>
+</svg>
+{% endmacro %}

--- a/app/templates/dataset_detail.html
+++ b/app/templates/dataset_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "components/labeled_file_icon.html" import labeled_file_icon %}
 
 {% set dataset_title = dataset.dcat.get('title') or dataset.slug or dataset.id %}
 {% set dataset_slug = dataset.slug %}
@@ -147,18 +148,19 @@
 
                         <li class="resources-list__item resources-list__item--main">
                             <div class="resources-list__info">
-                                {% set overlay_label = resource_format|format_overlay_label %}
-                                <div class="resources-list__icon{% if overlay_label %} resources-list__icon--badged{% endif %}">
+                                {% set icon_label = resource_format|format_icon_label %}
+                                <div class="resources-list__icon">
+                                    {% if icon_label %}
+                                    {{ labeled_file_icon(icon_label, resource_format) }}
+                                    {% else %}
                                     <span class="file-icon {{ resource_format|format_icon_class }}" aria-hidden="true"></span>
-                                    {% if overlay_label %}
-                                    <span class="resources-list__icon-badge">{{ overlay_label }}</span>
                                     {% endif %}
                                 </div>
                                 <div class="resources-list__details">
                                     <p class="resources-list__name" title="{{ resource_title }}">
                                         {{ resource_title }}
                                     </p>
-                                    <div class="resources-list__format">{{ resource_format }}</div>
+                                    <div class="resources-list__format" title="{{ resource_format }}">{{ resource_format }}</div>
                                 </div>
                             </div>
                             <div class="resources-list__actions">

--- a/app/templates/style_guide_icons.html
+++ b/app/templates/style_guide_icons.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "components/labeled_file_icon.html" import labeled_file_icon %}
 
 {% block title %}Style Guide — File Icons{% endblock %}
 
@@ -8,31 +9,42 @@
 <section class="usa-section">
     <h1 class="text-primary-darker">File-Type Icon Style Guide</h1>
     <p class="font-sans-md text-base-darker">
-        One example resource card per supported format. Icons with a dedicated
-        SVG render the SVG; unrecognized formats fall back to the default file
-        icon with an uppercase badge overlay.
+        One example resource card per format. Icons with a dedicated SVG render the
+        SVG; HTML and other unrecognized formats use a shared file outline with a
+        short extension label. Long format strings truncate in the subtitle — hover
+        to see the full value.
     </p>
 
-    <div class="style-guide-grid">
-        {% for sample in samples %}
-        {% set overlay_label = sample.format|format_overlay_label %}
-        <ul class="resources-list resources-list--main style-guide-grid__item">
-            <li class="resources-list__item resources-list__item--main">
-                <div class="resources-list__info">
-                    <div class="resources-list__icon{% if overlay_label %} resources-list__icon--badged{% endif %}">
-                        <span class="file-icon {{ sample.format|format_icon_class }}" aria-hidden="true"></span>
-                        {% if overlay_label %}
-                        <span class="resources-list__icon-badge">{{ overlay_label }}</span>
-                        {% endif %}
+    {% for section in sample_sections %}
+    <div class="style-guide-section">
+        <h2 class="style-guide-section__title">{{ section.title }}</h2>
+        {% if section.description %}
+        <p class="style-guide-section__description">{{ section.description }}</p>
+        {% endif %}
+
+        <div class="style-guide-grid">
+            {% for sample in section.samples %}
+            {% set icon_label = sample.format|format_icon_label %}
+            <ul class="resources-list resources-list--main style-guide-grid__item">
+                <li class="resources-list__item resources-list__item--main">
+                    <div class="resources-list__info">
+                        <div class="resources-list__icon">
+                            {% if icon_label %}
+                            {{ labeled_file_icon(icon_label, sample.format) }}
+                            {% else %}
+                            <span class="file-icon {{ sample.format|format_icon_class }}" aria-hidden="true"></span>
+                            {% endif %}
+                        </div>
+                        <div class="resources-list__details">
+                            <p class="resources-list__name">{{ sample.label }}</p>
+                            <div class="resources-list__format" title="{{ sample.format }}">{{ sample.format }}</div>
+                        </div>
                     </div>
-                    <div class="resources-list__details">
-                        <p class="resources-list__name">{{ sample.label }}</p>
-                        <div class="resources-list__format">{{ sample.format }}</div>
-                    </div>
-                </div>
-            </li>
-        </ul>
-        {% endfor %}
+                </li>
+            </ul>
+            {% endfor %}
+        </div>
     </div>
+    {% endfor %}
 </section>
 {% endblock %}

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -6,6 +6,7 @@ from app.filters import (
     dcatus_to_schema_org_jsonld,
     format_dcat_date,
     format_icon_class,
+    format_icon_label,
     format_overlay_label,
     parse_datetime,
     remove_html_tags,
@@ -193,9 +194,54 @@ class TestFormatOverlayLabel:
             ("WFS", "WFS"),
             ("GML", "GML"),
             ("SHP", "SHP"),
+            ("application/octet-stream", "BIN"),
+            ("APPLICATION/OCTET-STREAM", "BIN"),
+            ("octet-stream", "BIN"),
+            ("ARCGIS GEOSERVICES REST API", "REST"),
+            ("ArcGIS GeoServices REST API", "REST"),
+            ("application/vnd.google-earth.wmts", "WMTS"),
+            ("application/x-netcdf", "NETC"),
+            ("application/vnd.unknown-format", "UNKN"),
+            ("application/vnd.esri.mapserver", "MAPS"),
+            ("verylongformatname", "VERY"),
             ("", ""),
             (None, ""),
         ],
     )
     def test_returns_expected_badge(self, fmt, expected):
         assert format_overlay_label(fmt) == expected
+
+    @pytest.mark.parametrize(
+        "fmt, expected",
+        [
+            ("HTML", "HTML"),
+            ("application/xhtml+xml", "HTML"),
+            ("application/json", ""),
+            ("CSV", ""),
+            ("application/octet-stream", "BIN"),
+            ("ARCGIS GEOSERVICES REST API", "REST"),
+            ("KML", "KML"),
+            ("", ""),
+            (None, ""),
+        ],
+    )
+    def test_returns_expected_icon_label(self, fmt, expected):
+        assert format_icon_label(fmt) == expected
+
+    @pytest.mark.parametrize(
+        "fmt",
+        [
+            "application/octet-stream",
+            "APPLICATION/OCTET-STREAM",
+            "ARCGIS GEOSERVICES REST API",
+            "application/vnd.google-earth.kml+xml",
+            "application/x-netcdf",
+            "application/vnd.unknown-format",
+            "application/vnd.esri.mapserver",
+            "WMS",
+            "verylongformatname",
+        ],
+    )
+    def test_badge_labels_are_short(self, fmt):
+        label = format_overlay_label(fmt)
+        assert len(label) <= 4


### PR DESCRIPTION
updating the HTML icon and making other unsupported icons consistent with the HTML icon style.

also updating the style-guide/icons routes with more examples (most of the file changes in this PR are related to that).

<img width="921" height="931" alt="Screenshot 2026-06-03 at 1 10 15 PM" src="https://github.com/user-attachments/assets/448716ca-a49f-49bb-be08-8faf89e02e86" />

These have been deployed to https://catalog-dev.data.gov/

