### PR TITLE
Static assets cache

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 load_dotenv()
 
 htmx = None
+STATIC_ASSET_MAX_AGE_SECONDS = 60 * 60 * 24
 
 
 def register_template_filters(app):
@@ -37,6 +38,7 @@ def create_app(config_name: str = "local") -> APIFlask:
         app.config["SERVERS"] = [{"url": f"{os.getenv('SITE_URL')}"}]
 
     app.config["PREFERRED_URL_SCHEME"] = "https"
+    app.config["SEND_FILE_MAX_AGE_DEFAULT"] = STATIC_ASSET_MAX_AGE_SECONDS
     # enable template hot template reloading in local
     if config_name == "local" or app.config.get("FLASK_ENV") == "local":
         # Enable template auto-reload

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -29,6 +29,29 @@ def test_static_asset_cache_duration_by_environment():
     assert response.cache_control.max_age == STATIC_ASSET_MAX_AGE_SECONDS
 
 
+def test_non_static_pages_do_not_set_cache_duration():
+    # For regular pages, leave max_age unset
+    # to use the default caching behavior configured in CloudFront.
+    production_app = create_app("production")
+    client = production_app.test_client()
+
+    mock_interface = Mock()
+    mock_interface.search_datasets.return_value = SearchResult(
+        total=0,
+        results=[],
+        search_after=None,
+        aggregations={"keywords": [], "organizations": [], "publishers": []},
+    )
+    mock_interface.count_all_datasets_in_search.return_value = 0
+    mock_interface.get_organizations.return_value = []
+
+    with patch("app.routes.interface", mock_interface):
+        for path in ["/", "/openapi/docs", "/does-not-exist"]:
+            response = client.get(path)
+
+            assert response.cache_control.max_age is None
+
+
 def test_dataset_slug_api_endpoint(db_client, interface_with_dataset):
     # check an existing document by slug name and id
     # "test-dataset-2" is the id

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -6,9 +6,27 @@ from uuid import uuid4
 
 from bs4 import BeautifulSoup
 
+from app import STATIC_ASSET_MAX_AGE_SECONDS, create_app
 from app.database.opensearch import SearchResult
 from app.models import Dataset
 from tests.fixtures import HARVEST_RECORD_ID
+
+
+def test_static_asset_cache_duration_by_environment():
+    production_app = create_app("production")
+    local_app = create_app("local")
+
+    assert production_app.config["SEND_FILE_MAX_AGE_DEFAULT"] == 60 * 60 * 24
+    assert production_app.config["SEND_FILE_MAX_AGE_DEFAULT"] == (
+        STATIC_ASSET_MAX_AGE_SECONDS
+    )
+    assert local_app.config["SEND_FILE_MAX_AGE_DEFAULT"] == 0
+
+    response = production_app.test_client().get("/js/datetime.js")
+
+    assert response.status_code == 200
+    assert response.cache_control.public
+    assert response.cache_control.max_age == STATIC_ASSET_MAX_AGE_SECONDS
 
 
 def test_dataset_slug_api_endpoint(db_client, interface_with_dataset):


### PR DESCRIPTION
This comes from a [slack discussion](https://gsa-tts.slack.com/archives/C2N85536E/p1780429132864849). The team decided to add cache busting versions to static assets. To go with it, it make sense to set a long (24 hour vs 1 hour) max_age for static asset files to minimize the risk of user seeing new assets with cache html pages. 