### PR TITLE
Adding Approach for Static Asset Cache Clearing

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -88,11 +88,15 @@ runs:
       shell: bash
       run: make update-dependencies && cat requirements.txt
 
+    - name: Set deploy asset version
+      shell: bash
+      run: echo "asset_version=${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
+
     - name: Deploy datagov-catalog app
       uses: cloud-gov/cg-cli-tools@main
       with:
         command: >-
-          ${{ inputs.command }} --vars-file vars.${{ inputs.cf_space }}.yml
+          ${{ inputs.command }} --vars-file vars.${{ inputs.cf_space }}.yml --var asset_version=${{ env.asset_version }}
         cf_org: ${{ inputs.cf_org }}
         cf_space: ${{ inputs.cf_space }}
         cf_username: ${{ inputs.cf_username }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -73,6 +73,13 @@ runs:
       shell: bash
       run: make install-static
 
+    - name: Set deploy asset version
+      shell: bash
+      run: |
+        asset_version="$(.github/scripts/compute-asset-version.sh)"
+        echo "asset_version=${asset_version}" >> "$GITHUB_ENV"
+        echo "Static asset version: ${asset_version}"
+
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -87,10 +94,6 @@ runs:
     - name: Add requirements.txt
       shell: bash
       run: make update-dependencies && cat requirements.txt
-
-    - name: Set deploy asset version
-      shell: bash
-      run: echo "asset_version=${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
 
     - name: Deploy datagov-catalog app
       uses: cloud-gov/cg-cli-tools@main

--- a/.github/scripts/compute-asset-version.sh
+++ b/.github/scripts/compute-asset-version.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Hash served static files after `make install-static`.
+# Includes built output (assets/) plus JS/CSS served directly from source.
+find app/static/assets app/static/js app/static/css -type f \
+  | sort \
+  | xargs sha256sum \
+  | sha256sum \
+  | awk '{print substr($1, 1, 7)}'

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,8 +22,12 @@ STATIC_ASSET_MAX_AGE_SECONDS = 60 * 60 * 24
 def register_template_filters(app):
     import app.filters as filters
 
+    from .static_assets import static_url
+
     for name in filters.__all__:
         app.add_template_filter(getattr(filters, name))
+
+    app.add_template_global(static_url, "static_url")
 
 
 def create_app(config_name: str = "local") -> APIFlask:
@@ -37,7 +41,10 @@ def create_app(config_name: str = "local") -> APIFlask:
     if os.getenv("SITE_URL"):
         app.config["SERVERS"] = [{"url": f"{os.getenv('SITE_URL')}"}]
 
+    from .static_assets import get_asset_version
+
     app.config["PREFERRED_URL_SCHEME"] = "https"
+    app.config["ASSET_VERSION"] = get_asset_version()
     app.config["SEND_FILE_MAX_AGE_DEFAULT"] = STATIC_ASSET_MAX_AGE_SECONDS
     # enable template hot template reloading in local
     if config_name == "local" or app.config.get("FLASK_ENV") == "local":

--- a/app/filters.py
+++ b/app/filters.py
@@ -8,15 +8,15 @@ from datetime import date, datetime
 from typing import Any, Union
 
 from bs4 import BeautifulSoup
-from flask import url_for
 
+from app.static_assets import static_url
 from shared.constants import ORGANIZATION_TYPE_VALUES
 
 
 def usa_icon(icon_name: str) -> str:
     """Return SVG markup for a USWDS icon referenced from the sprite sheet."""
 
-    sprite_path = url_for("static", filename="assets/uswds/img/sprite.svg")
+    sprite_path = static_url("assets/uswds/img/sprite.svg")
     return (
         '<svg class="usa-icon" aria-hidden="true" role="img">'
         f'<use xlink:href="{sprite_path}#{icon_name}"></use>'

--- a/app/static/_scss/components/_footer.scss
+++ b/app/static/_scss/components/_footer.scss
@@ -17,6 +17,10 @@
     padding-top: 0;
     color: #284a7a;
 }
+.footer-logo img {
+    width: 200px;
+    height: auto;
+}
 .footer-logo a.logo-brand {
     margin-bottom: 1em;
     margin-top: 0;

--- a/app/static_assets.py
+++ b/app/static_assets.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from urllib.parse import urlencode
 
 from flask import current_app, url_for
@@ -14,24 +13,7 @@ DEFAULT_ASSET_VERSION = "dev"
 def get_asset_version() -> str:
     """Return the cache-bust version for static assets."""
     env_version = os.getenv("ASSET_VERSION", "").strip()
-    if env_version:
-        return env_version
-
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--short=7", "HEAD"],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=2,
-        )
-        version = result.stdout.strip()
-        if version:
-            return version
-    except (OSError, subprocess.SubprocessError):
-        pass
-
-    return DEFAULT_ASSET_VERSION
+    return env_version or DEFAULT_ASSET_VERSION
 
 
 def static_url(filename: str) -> str:

--- a/app/static_assets.py
+++ b/app/static_assets.py
@@ -1,0 +1,41 @@
+"""Helpers for versioned static asset URLs."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from urllib.parse import urlencode
+
+from flask import current_app, url_for
+
+DEFAULT_ASSET_VERSION = "dev"
+
+
+def get_asset_version() -> str:
+    """Return the cache-bust version for static assets."""
+    env_version = os.getenv("ASSET_VERSION", "").strip()
+    if env_version:
+        return env_version
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short=7", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=2,
+        )
+        version = result.stdout.strip()
+        if version:
+            return version
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+    return DEFAULT_ASSET_VERSION
+
+
+def static_url(filename: str) -> str:
+    """Return a static asset URL with a cache-bust query parameter."""
+    version = current_app.config.get("ASSET_VERSION", DEFAULT_ASSET_VERSION)
+    base_url = url_for("static", filename=filename)
+    return f"{base_url}?{urlencode({'v': version})}"

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,12 +12,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Catalog - Data.gov{% endblock %}</title>
   {% block head_extra %}{% endblock %}
-  <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='assets/img/favicon.ico') }}">
-  <link rel="stylesheet" href="{{ url_for('static', filename='assets/uswds/css/styles.css') }}">
+  <link rel="icon" type="image/x-icon" href="{{ static_url('assets/img/favicon.ico') }}">
+  <link rel="stylesheet" href="{{ static_url('assets/uswds/css/styles.css') }}">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
-  <script src="{{ url_for('static', filename='assets/uswds/js/uswds-init.js') }}"></script>
-  <script src="{{ url_for('static', filename='assets/htmx/htmx.min.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/datetime.js') }}"></script>
+  <script src="{{ static_url('assets/uswds/js/uswds-init.js') }}"></script>
+  <script src="{{ static_url('assets/htmx/htmx.min.js') }}"></script>
+  <script src="{{ static_url('js/datetime.js') }}"></script>
   <!-- zendesk -->
   <script id="ze-snippet"
     src="https://static.zdassets.com/ekr/snippet.js?key=d9b8cbcb-4275-46af-a445-49ce9c4a22c0"></script>
@@ -48,8 +48,8 @@
 
   {% include "components/footer.html" %}
 
-  <script src="{{ url_for('static', filename='assets/uswds/js/uswds.js') }}"></script>
-  <script src="{{ url_for('static', filename='assets/js/bundle.js') }}"></script>
+  <script src="{{ static_url('assets/uswds/js/uswds.js') }}"></script>
+  <script src="{{ static_url('assets/js/bundle.js') }}"></script>
   <!-- Load the GitHub buttons script -->
   <script async defer src="https://buttons.github.io/buttons.js"></script>
   {% block scripts %}{% endblock %}

--- a/app/templates/components/footer.html
+++ b/app/templates/components/footer.html
@@ -5,7 +5,7 @@
       <div class="tablet:grid-col-auto">
         <div class="logo-links">
           <a class="footer-logo media_link" href="https://data.gov">
-            <img class="width-30 height-auto" src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/logo.png" alt="Data.gov logo">
+            <img src="{{ static_url('assets/img/logo.svg') }}" alt="Data.gov logo">
           </a>
         </div>
         <div class="grid-row grid-gap" id="menu-footer">

--- a/app/templates/components/header.html
+++ b/app/templates/components/header.html
@@ -3,7 +3,7 @@
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
-          <img class="usa-banner__header-flag" src="{{ url_for('static', filename='assets/uswds/img/us_flag_small.png') }}"
+          <img class="usa-banner__header-flag" src="{{ static_url('assets/uswds/img/us_flag_small.png') }}"
             alt="U.S. flag">
         </div>
         <div class="grid-col-fill tablet:grid-col-auto">
@@ -20,7 +20,7 @@
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img"
-            src="{{ url_for('static', filename='assets/uswds/img/icon-dot-gov.svg') }}"
+            src="{{ static_url('assets/uswds/img/icon-dot-gov.svg') }}"
             role="img" alt="Dot gov">
           <div class="usa-media-block__body">
             <p>
@@ -32,7 +32,7 @@
         </div>
         <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img"
-            src="{{ url_for('static', filename='assets/uswds/img/icon-https.svg') }}"
+            src="{{ static_url('assets/uswds/img/icon-https.svg') }}"
             role="img" alt="Https">
           <div class="usa-media-block__body">
             <p>

--- a/app/templates/components/navigation.html
+++ b/app/templates/components/navigation.html
@@ -9,7 +9,7 @@
     </div>
     <nav aria-label="Primary navigation" class="usa-nav">
       <button class="usa-nav__close" type="button">
-        <img src="{{ url_for('static', filename='assets/uswds/img/usa-icons/close.svg') }}" role="img" alt="Close">
+        <img src="{{ static_url('assets/uswds/img/usa-icons/close.svg') }}" role="img" alt="Close">
       </button>
       <ul class="usa-nav__primary usa-accordion">
         <li class="usa-nav__primary-item">

--- a/app/templates/dataset_detail.html
+++ b/app/templates/dataset_detail.html
@@ -258,9 +258,7 @@
                                     data-classes="tablet:width-auto"
                                     title="A 'collection' is a group of related datasets by the data provider"
                                 >
-                                    <svg class="usa-icon" aria-hidden="true">
-                                        <use href="/assets/uswds/img/sprite.svg#info"></use>
-                                    </svg>
+                                    {{ 'info' | usa_icon | safe }}
                                 </button>
                             </div>
 

--- a/app/templates/dataset_detail.html
+++ b/app/templates/dataset_detail.html
@@ -432,11 +432,11 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/dataset_tags.js') }}"></script>
+<script src="{{ static_url('js/dataset_tags.js') }}"></script>
 {% if dataset.translated_spatial %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/vendor/leaflet.css') }}" />
-<script src="{{ url_for('static', filename='js/vendor/leaflet.js') }}"></script>
-<script src="{{ url_for('static', filename='js/view_bbox_map.js') }}"></script>
+<link rel="stylesheet" href="{{ static_url('css/vendor/leaflet.css') }}" />
+<script src="{{ static_url('js/vendor/leaflet.js') }}"></script>
+<script src="{{ static_url('js/view_bbox_map.js') }}"></script>
 </script>
 {% endif %}
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -185,9 +185,9 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/filter_form_auto_submit.js') }}"></script>
-<script src="{{ url_for('static', filename='js/filters_autocomplete.js') }}"></script>
-<script src="{{ url_for('static', filename='js/geography_autocomplete.js') }}"></script>
-<link rel="stylesheet" href="{{ url_for('static', filename='css/vendor/leaflet.css') }}"/>
-<script src="{{ url_for('static', filename='js/vendor/leaflet.js') }}"></script>
+<script src="{{ static_url('js/filter_form_auto_submit.js') }}"></script>
+<script src="{{ static_url('js/filters_autocomplete.js') }}"></script>
+<script src="{{ static_url('js/geography_autocomplete.js') }}"></script>
+<link rel="stylesheet" href="{{ static_url('css/vendor/leaflet.css') }}"/>
+<script src="{{ static_url('js/vendor/leaflet.js') }}"></script>
 {% endblock %}

--- a/app/templates/organization_detail.html
+++ b/app/templates/organization_detail.html
@@ -155,11 +155,11 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/filter_form_auto_submit.js') }}"></script>
-<script src="{{ url_for('static', filename='js/filters_autocomplete.js') }}"></script>
-<script src="{{ url_for('static', filename='js/geography_autocomplete.js') }}"></script>
-<link rel="stylesheet" href="{{ url_for('static', filename='css/vendor/leaflet.css') }}"/>
-<script src="{{ url_for('static', filename='js/vendor/leaflet.js') }}"></script>
+<script src="{{ static_url('js/filter_form_auto_submit.js') }}"></script>
+<script src="{{ static_url('js/filters_autocomplete.js') }}"></script>
+<script src="{{ static_url('js/geography_autocomplete.js') }}"></script>
+<link rel="stylesheet" href="{{ static_url('css/vendor/leaflet.css') }}"/>
+<script src="{{ static_url('js/vendor/leaflet.js') }}"></script>
 {% endblock %}
 
 {% block head_extra %}

--- a/manifest.yml
+++ b/manifest.yml
@@ -39,4 +39,5 @@ applications:
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
       NEW_RELIC_CONFIG_FILE: /home/vcap/app/config/newrelic.ini
       SITE_URL: ((site_url))
+      ASSET_VERSION: ((asset_version))
     command: ./app-start.sh

--- a/tests/unit/test_static_assets.py
+++ b/tests/unit/test_static_assets.py
@@ -1,0 +1,40 @@
+from unittest.mock import Mock
+
+from app.static_assets import DEFAULT_ASSET_VERSION, get_asset_version, static_url
+
+
+def test_get_asset_version_uses_env_var(monkeypatch):
+    monkeypatch.setenv("ASSET_VERSION", "abc1234")
+    assert get_asset_version() == "abc1234"
+
+
+def test_get_asset_version_falls_back_to_dev_when_git_unavailable(monkeypatch):
+    monkeypatch.delenv("ASSET_VERSION", raising=False)
+
+    def fail_git(*args, **kwargs):
+        raise OSError("git not found")
+
+    monkeypatch.setattr("app.static_assets.subprocess.run", fail_git)
+    assert get_asset_version() == DEFAULT_ASSET_VERSION
+
+
+def test_get_asset_version_uses_git_when_env_unset(monkeypatch):
+    monkeypatch.delenv("ASSET_VERSION", raising=False)
+    monkeypatch.setattr(
+        "app.static_assets.subprocess.run",
+        Mock(
+            return_value=Mock(
+                stdout="8eb9d3e\n",
+            )
+        ),
+    )
+    assert get_asset_version() == "8eb9d3e"
+
+
+def test_static_url_appends_version_query(app):
+    app.config["ASSET_VERSION"] = "8eb9d3e"
+    with app.test_request_context("/"):
+        url = static_url("js/filter_sidebar_toggle.js")
+
+    assert url.endswith("?v=8eb9d3e")
+    assert "/js/filter_sidebar_toggle.js" in url

--- a/tests/unit/test_static_assets.py
+++ b/tests/unit/test_static_assets.py
@@ -1,5 +1,3 @@
-from unittest.mock import Mock
-
 from app.static_assets import DEFAULT_ASSET_VERSION, get_asset_version, static_url
 
 
@@ -8,27 +6,9 @@ def test_get_asset_version_uses_env_var(monkeypatch):
     assert get_asset_version() == "abc1234"
 
 
-def test_get_asset_version_falls_back_to_dev_when_git_unavailable(monkeypatch):
+def test_get_asset_version_falls_back_to_dev_when_env_unset(monkeypatch):
     monkeypatch.delenv("ASSET_VERSION", raising=False)
-
-    def fail_git(*args, **kwargs):
-        raise OSError("git not found")
-
-    monkeypatch.setattr("app.static_assets.subprocess.run", fail_git)
     assert get_asset_version() == DEFAULT_ASSET_VERSION
-
-
-def test_get_asset_version_uses_git_when_env_unset(monkeypatch):
-    monkeypatch.delenv("ASSET_VERSION", raising=False)
-    monkeypatch.setattr(
-        "app.static_assets.subprocess.run",
-        Mock(
-            return_value=Mock(
-                stdout="8eb9d3e\n",
-            )
-        ),
-    )
-    assert get_asset_version() == "8eb9d3e"
 
 
 def test_static_url_appends_version_query(app):

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -10,3 +10,4 @@ basic_auth_enabled: on # nginx terminology 'on' 'off'. cf will interpret these a
 route_external: catalog-dev.data.gov
 route_beta: catalog-beta-dev.app.cloud.gov # an invalid url because there's no 'beta' equivalent
 route_internal: datagov-catalog-dev.apps.internal
+asset_version: dev

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -10,4 +10,5 @@ basic_auth_enabled: on # nginx terminology 'on' 'off'. cf will interpret these a
 route_external: catalog-dev.data.gov
 route_beta: catalog-beta-dev.app.cloud.gov # an invalid url because there's no 'beta' equivalent
 route_internal: datagov-catalog-dev.apps.internal
-asset_version: dev
+# Placeholder for manifest ((asset_version)); CI overrides via --var on deploy
+asset_version: set-at-deploy

--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -10,3 +10,4 @@ basic_auth_enabled: off # nginx terminology 'on' 'off'. cf will interpret these 
 route_external: catalog.data.gov
 route_beta: catalog-beta.data.gov  
 route_internal: datagov-catalog-prod.apps.internal
+asset_version: unversioned

--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -10,4 +10,5 @@ basic_auth_enabled: off # nginx terminology 'on' 'off'. cf will interpret these 
 route_external: catalog.data.gov
 route_beta: catalog-beta.data.gov  
 route_internal: datagov-catalog-prod.apps.internal
-asset_version: unversioned
+# Placeholder for manifest ((asset_version)); CI overrides via --var on deploy
+asset_version: set-at-deploy

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -10,4 +10,5 @@ basic_auth_enabled: on # nginx terminology 'on' 'off'. cf will interpret these a
 route_external: catalog-stage.data.gov
 route_beta: unused-staging-redirect.invalid # an invalid url because there's no 'beta' equivalent
 route_internal: datagov-catalog-staging.apps.internal
-asset_version: unversioned
+# Placeholder for manifest ((asset_version)); CI overrides via --var on deploy
+asset_version: set-at-deploy

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -10,3 +10,4 @@ basic_auth_enabled: on # nginx terminology 'on' 'off'. cf will interpret these a
 route_external: catalog-stage.data.gov
 route_beta: unused-staging-redirect.invalid # an invalid url because there's no 'beta' equivalent
 route_internal: datagov-catalog-staging.apps.internal
+asset_version: unversioned


### PR DESCRIPTION
## Summary

This PR adds a `static_url()` helper so templates emit versioned static URLs (`?v=…`), which lets browsers cache CSS, JS, and images without serving stale files after a deploy.

On deploy, CI runs `make install-static`, then hashes every file under `app/static/assets`, `app/static/js`, and `app/static/css`. The first seven characters of that hash become `ASSET_VERSION` in Cloud Foundry, so the query string only changes when static content changes—not on every commit. Locally, the version comes from `ASSET_VERSION` if set, otherwise the short git SHA, otherwise `dev`.

Fixing one place in html that was not using the static_url helper.

Updated the footer to use the logo svg instead of pointing to a us-west bucket for the logo.