### PR TITLE
adding sha in file name instead of appended at the end

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,9 +21,15 @@ STATIC_ASSET_MAX_AGE_SECONDS = 60 * 60 * 24
 
 class VersionedStaticAPIFlask(APIFlask):
     def send_static_file(self, filename):
-        from .static_assets import DEFAULT_ASSET_VERSION, unversion_static_filename
+        from .static_assets import (
+            DEFAULT_ASSET_VERSION,
+            unversion_static_filename,
+            validate_asset_version,
+        )
 
-        version = self.config.get("ASSET_VERSION", DEFAULT_ASSET_VERSION)
+        version = validate_asset_version(
+            self.config.get("ASSET_VERSION", DEFAULT_ASSET_VERSION)
+        )
         return super().send_static_file(unversion_static_filename(filename, version))
 
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -118,6 +118,7 @@ def create_app(config_name: str = "local") -> APIFlask:
 
         response.cache_control.public = True
         response.cache_control.max_age = HTML_PAGE_MAX_AGE_SECONDS
+        response.cache_control.must_revalidate = True
         return response
 
     @app.errorhandler(404)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,6 +17,7 @@ load_dotenv()
 
 htmx = None
 STATIC_ASSET_MAX_AGE_SECONDS = 60 * 60 * 24
+HTML_PAGE_MAX_AGE_SECONDS = 60 * 60
 
 
 def register_template_filters(app):
@@ -86,6 +87,22 @@ def create_app(config_name: str = "local") -> APIFlask:
     register_commands(app)
 
     register_template_filters(app)
+
+    @app.after_request
+    def set_html_cache_control(response):
+        if is_local:
+            return response
+
+        content_type = response.content_type or ""
+        if not content_type.startswith("text/html"):
+            return response
+
+        if response.cache_control.max_age is not None:
+            return response
+
+        response.cache_control.public = True
+        response.cache_control.max_age = HTML_PAGE_MAX_AGE_SECONDS
+        return response
 
     @app.errorhandler(404)
     def not_found(error):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,6 +19,14 @@ htmx = None
 STATIC_ASSET_MAX_AGE_SECONDS = 60 * 60 * 24
 
 
+class VersionedStaticAPIFlask(APIFlask):
+    def send_static_file(self, filename):
+        from .static_assets import DEFAULT_ASSET_VERSION, unversion_static_filename
+
+        version = self.config.get("ASSET_VERSION", DEFAULT_ASSET_VERSION)
+        return super().send_static_file(unversion_static_filename(filename, version))
+
+
 def register_template_filters(app):
     import app.filters as filters
 
@@ -36,7 +44,9 @@ def register_template_filters(app):
 
 
 def create_app(config_name: str = "local") -> APIFlask:
-    app = APIFlask(__name__, static_url_path="", static_folder="static", docs_path=None)
+    app = VersionedStaticAPIFlask(
+        __name__, static_url_path="", static_folder="static", docs_path=None
+    )
 
     app.config["CONFIG_NAME"] = config_name
     app.config["INFO"] = {

--- a/app/static_assets.py
+++ b/app/static_assets.py
@@ -1,16 +1,27 @@
 """Helpers for versioned static asset URLs."""
 
 import os
+import re
 
 from flask import current_app, url_for
 
 DEFAULT_ASSET_VERSION = "dev"
+ASSET_VERSION_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def validate_asset_version(version: str) -> str:
+    """Return a filename-safe static asset version."""
+    if not ASSET_VERSION_PATTERN.fullmatch(version):
+        raise ValueError(
+            "ASSET_VERSION must contain only letters, numbers, underscores, or hyphens"
+        )
+    return version
 
 
 def get_asset_version() -> str:
     """Return the cache-bust version for static assets."""
     env_version = os.getenv("ASSET_VERSION", "").strip()
-    return env_version or DEFAULT_ASSET_VERSION
+    return validate_asset_version(env_version or DEFAULT_ASSET_VERSION)
 
 
 def versioned_static_filename(filename: str, version: str) -> str:
@@ -35,5 +46,7 @@ def unversion_static_filename(filename: str, version: str) -> str:
 
 def static_url(filename: str) -> str:
     """Return a static asset URL with the cache-bust version in the filename."""
-    version = current_app.config.get("ASSET_VERSION", DEFAULT_ASSET_VERSION)
+    version = validate_asset_version(
+        current_app.config.get("ASSET_VERSION", DEFAULT_ASSET_VERSION)
+    )
     return url_for("static", filename=versioned_static_filename(filename, version))

--- a/app/static_assets.py
+++ b/app/static_assets.py
@@ -1,7 +1,6 @@
 """Helpers for versioned static asset URLs."""
 
 import os
-from urllib.parse import urlencode
 
 from flask import current_app, url_for
 
@@ -14,8 +13,27 @@ def get_asset_version() -> str:
     return env_version or DEFAULT_ASSET_VERSION
 
 
+def versioned_static_filename(filename: str, version: str) -> str:
+    """Embed the static asset version before the file extension."""
+    path, extension = os.path.splitext(filename)
+    if extension:
+        return f"{path}.{version}{extension}"
+    return f"{filename}.{version}"
+
+
+def unversion_static_filename(filename: str, version: str) -> str:
+    """Return the on-disk filename for a versioned static asset request."""
+    path, extension = os.path.splitext(filename)
+    version_suffix = f".{version}"
+
+    if extension and path.endswith(version_suffix):
+        return f"{path[: -len(version_suffix)]}{extension}"
+    if not extension and filename.endswith(version_suffix):
+        return filename[: -len(version_suffix)]
+    return filename
+
+
 def static_url(filename: str) -> str:
-    """Return a static asset URL with a cache-bust query parameter."""
+    """Return a static asset URL with the cache-bust version in the filename."""
     version = current_app.config.get("ASSET_VERSION", DEFAULT_ASSET_VERSION)
-    base_url = url_for("static", filename=filename)
-    return f"{base_url}?{urlencode({'v': version})}"
+    return url_for("static", filename=versioned_static_filename(filename, version))

--- a/tests/unit/test_dataset_detail.py
+++ b/tests/unit/test_dataset_detail.py
@@ -1,4 +1,5 @@
 import json
+import re
 from unittest.mock import patch
 
 import pytest
@@ -6,6 +7,11 @@ from bs4 import BeautifulSoup
 
 from app.utils import hint_from_dict
 from tests.fixtures import DATASET_ID, DEFAULT_LAST_HARVESTED_DATE
+
+
+def versioned_asset_url(filename):
+    path, extension = filename.rsplit(".", maxsplit=1)
+    return re.compile(rf"/{re.escape(path)}\.[^/]+\.{re.escape(extension)}(?:[?#]|$)")
 
 
 class TestDatasetDetail:
@@ -270,9 +276,13 @@ class TestDatasetDetail:
         assert map_div.get("data-geometry") is not None
 
         # Leaflet assets (conditionally included)
-        leaflet_css = soup.select_one('link[href*="leaflet.css"]')
-        leaflet_js = soup.select_one('script[src*="leaflet.js"]')
-        view_js = soup.select_one('script[src*="js/view_bbox_map.js"]')
+        leaflet_css = soup.find(
+            "link", href=versioned_asset_url("css/vendor/leaflet.css")
+        )
+        leaflet_js = soup.find(
+            "script", src=versioned_asset_url("js/vendor/leaflet.js")
+        )
+        view_js = soup.find("script", src=versioned_asset_url("js/view_bbox_map.js"))
         assert leaflet_css is not None
         assert leaflet_js is not None
         assert view_js is not None
@@ -302,9 +312,13 @@ class TestDatasetDetail:
         assert geometry_attr is not None
         assert json.loads(geometry_attr) == ds.translated_spatial
 
-        leaflet_css = soup.select_one('link[href*="leaflet.css"]')
-        leaflet_js = soup.select_one('script[src*="leaflet.js"]')
-        view_js = soup.select_one('script[src*="js/view_bbox_map.js"]')
+        leaflet_css = soup.find(
+            "link", href=versioned_asset_url("css/vendor/leaflet.css")
+        )
+        leaflet_js = soup.find(
+            "script", src=versioned_asset_url("js/vendor/leaflet.js")
+        )
+        view_js = soup.find("script", src=versioned_asset_url("js/view_bbox_map.js"))
         assert leaflet_css is not None
         assert leaflet_js is not None
         assert view_js is not None
@@ -327,9 +341,16 @@ class TestDatasetDetail:
         assert soup.select_one("#dataset-map") is None
 
         # No Leaflet assets
-        assert soup.select_one('link[href*="leaflet.css"]') is None
-        assert soup.select_one('script[src*="leaflet.js"]') is None
-        assert soup.select_one('script[src*="js/view_bbox_map.js"]') is None
+        assert (
+            soup.find("link", href=versioned_asset_url("css/vendor/leaflet.css"))
+            is None
+        )
+        assert (
+            soup.find("script", src=versioned_asset_url("js/vendor/leaflet.js")) is None
+        )
+        assert (
+            soup.find("script", src=versioned_asset_url("js/view_bbox_map.js")) is None
+        )
 
     @pytest.mark.parametrize(
         "dataset_detail_url",

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from bs4 import BeautifulSoup
 
-from app import STATIC_ASSET_MAX_AGE_SECONDS, create_app
+from app import HTML_PAGE_MAX_AGE_SECONDS, STATIC_ASSET_MAX_AGE_SECONDS, create_app
 from app.database.opensearch import SearchResult
 from app.models import Dataset, Organization
 from tests.fixtures import HARVEST_RECORD_ID
@@ -29,9 +29,7 @@ def test_static_asset_cache_duration_by_environment():
     assert response.cache_control.max_age == STATIC_ASSET_MAX_AGE_SECONDS
 
 
-def test_non_static_pages_do_not_set_cache_duration():
-    # For regular pages, leave max_age unset
-    # to use the default caching behavior configured in CloudFront.
+def test_html_pages_set_one_hour_cache_duration_in_production():
     production_app = create_app("production")
     client = production_app.test_client()
 
@@ -49,7 +47,37 @@ def test_non_static_pages_do_not_set_cache_duration():
         for path in ["/", "/openapi/docs", "/does-not-exist"]:
             response = client.get(path)
 
-            assert response.cache_control.max_age is None
+            assert response.cache_control.public
+            assert response.cache_control.max_age == HTML_PAGE_MAX_AGE_SECONDS
+
+
+def test_html_pages_do_not_set_cache_duration_in_local():
+    local_app = create_app("local")
+    client = local_app.test_client()
+
+    mock_interface = Mock()
+    mock_interface.search_datasets.return_value = SearchResult(
+        total=0,
+        results=[],
+        search_after=None,
+        aggregations={"keywords": [], "organizations": [], "publishers": []},
+    )
+    mock_interface.count_all_datasets_in_search.return_value = 0
+    mock_interface.get_organizations.return_value = []
+
+    with patch("app.routes.interface", mock_interface):
+        response = client.get("/")
+
+    assert response.cache_control.max_age is None
+
+
+def test_api_responses_do_not_set_html_cache_duration(
+    db_client, interface_with_dataset
+):
+    with patch("app.routes.interface", interface_with_dataset):
+        response = db_client.get("/api/dataset/test-health-data")
+
+    assert response.cache_control.max_age is None
 
 
 def test_dataset_slug_api_endpoint(db_client, interface_with_dataset):

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -1752,7 +1752,7 @@ def test_index_active_organization_filter_expanded_in_html(db_client):
 def test_index_filter_accordion_script_included(db_client):
     response = db_client.get("/")
     assert response.status_code == 200
-    assert "js/filter_accordion.js" in response.text
+    assert re.search(r"/js/filter_accordion\.[^/]+\.js(?:[?#\"']|$)", response.text)
 
 
 def test_index_filter_mobile_trigger_and_toggle_script(db_client):
@@ -1770,7 +1770,9 @@ def test_index_filter_mobile_trigger_and_toggle_script(db_client):
     assert panel.find(class_="filter-sidebar") is not None
     assert panel.has_attr("hidden")
 
-    assert "js/filter_sidebar_toggle.js" in response.text
+    assert re.search(
+        r"/js/filter_sidebar_toggle\.[^/]+\.js(?:[?#\"']|$)", response.text
+    )
     assert "js/filter_sidebar_modal.js" not in response.text
 
 

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -49,6 +49,7 @@ def test_html_pages_set_one_hour_cache_duration_in_production():
 
             assert response.cache_control.public
             assert response.cache_control.max_age == HTML_PAGE_MAX_AGE_SECONDS
+            assert response.cache_control.must_revalidate
 
 
 def test_html_pages_do_not_set_cache_duration_in_local():

--- a/tests/unit/test_static_assets.py
+++ b/tests/unit/test_static_assets.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.static_assets import (
     DEFAULT_ASSET_VERSION,
     get_asset_version,
@@ -15,6 +17,21 @@ def test_get_asset_version_uses_env_var(monkeypatch):
 def test_get_asset_version_falls_back_to_dev_when_env_unset(monkeypatch):
     monkeypatch.delenv("ASSET_VERSION", raising=False)
     assert get_asset_version() == DEFAULT_ASSET_VERSION
+
+
+@pytest.mark.parametrize("asset_version", ["../secret", "abc/123", "abc.123", ""])
+def test_static_url_rejects_unsafe_asset_version(app, asset_version):
+    app.config["ASSET_VERSION"] = asset_version
+
+    with app.test_request_context("/"), pytest.raises(ValueError):
+        static_url("js/filter_sidebar_toggle.js")
+
+
+def test_get_asset_version_rejects_unsafe_env_var(monkeypatch):
+    monkeypatch.setenv("ASSET_VERSION", "../secret")
+
+    with pytest.raises(ValueError):
+        get_asset_version()
 
 
 def test_static_url_embeds_version_in_filename(app):

--- a/tests/unit/test_static_assets.py
+++ b/tests/unit/test_static_assets.py
@@ -1,4 +1,10 @@
-from app.static_assets import DEFAULT_ASSET_VERSION, get_asset_version, static_url
+from app.static_assets import (
+    DEFAULT_ASSET_VERSION,
+    get_asset_version,
+    static_url,
+    unversion_static_filename,
+    versioned_static_filename,
+)
 
 
 def test_get_asset_version_uses_env_var(monkeypatch):
@@ -11,10 +17,36 @@ def test_get_asset_version_falls_back_to_dev_when_env_unset(monkeypatch):
     assert get_asset_version() == DEFAULT_ASSET_VERSION
 
 
-def test_static_url_appends_version_query(app):
+def test_static_url_embeds_version_in_filename(app):
     app.config["ASSET_VERSION"] = "8eb9d3e"
     with app.test_request_context("/"):
         url = static_url("js/filter_sidebar_toggle.js")
 
-    assert url.endswith("?v=8eb9d3e")
-    assert "/js/filter_sidebar_toggle.js" in url
+    assert url.endswith("/js/filter_sidebar_toggle.8eb9d3e.js")
+    assert "?v=" not in url
+
+
+def test_static_url_preserves_existing_filename_dots(app):
+    app.config["ASSET_VERSION"] = "8eb9d3e"
+    with app.test_request_context("/"):
+        url = static_url("assets/htmx/htmx.min.js")
+
+    assert url.endswith("/assets/htmx/htmx.min.8eb9d3e.js")
+
+
+def test_versioned_static_filename_maps_back_to_on_disk_filename():
+    filename = "assets/htmx/htmx.min.js"
+
+    versioned_filename = versioned_static_filename(filename, "8eb9d3e")
+
+    assert versioned_filename == "assets/htmx/htmx.min.8eb9d3e.js"
+    assert unversion_static_filename(versioned_filename, "8eb9d3e") == filename
+    assert unversion_static_filename(filename, "8eb9d3e") == filename
+
+
+def test_versioned_static_asset_request_serves_on_disk_file(app):
+    app.config["ASSET_VERSION"] = "8eb9d3e"
+
+    response = app.test_client().get("/js/datetime.8eb9d3e.js")
+
+    assert response.status_code == 200


### PR DESCRIPTION
- adding a max-age to the returned html files so that a browser should only cache at max for 1 hour
- changing the cache sha to live in the file names instead of query strings at the end