### PR TITLE
theme spatial makes dataset geospatial

### DIFF
--- a/app/database/opensearch.py
+++ b/app/database/opensearch.py
@@ -504,8 +504,17 @@ class OpenSearchInterface:
         """
         # Check if dataset has spatial data
         spatial_value = dataset.dcat.get("spatial")
-        has_spatial = bool(spatial_value and str(spatial_value).strip()) or (
-            dataset.translated_spatial is not None
+        themes = dataset.dcat.get("theme") or []
+        if isinstance(themes, str):
+            themes = [themes]
+        has_spatial_theme = any(
+            isinstance(theme, str) and theme.strip().lower() == "geospatial"
+            for theme in themes
+        )
+        has_spatial = (
+            bool(spatial_value and str(spatial_value).strip())
+            or (dataset.translated_spatial is not None)
+            or has_spatial_theme
         )
 
         # Normalize DCAT dates to ensure they're strings

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -299,6 +299,38 @@ class TestDatasetToDocument:
         assert isinstance(document["dcat"]["modified"], str)
         assert document["dcat"]["modified"] == "2023-01-15T10:30:00"
 
+    @pytest.mark.parametrize(
+        "theme",
+        [
+            ["Geospatial"],
+            ["GEOSPATIAL"],
+            ["Health", " geospatial "],
+            "Geospatial",
+        ],
+    )
+    def test_dataset_to_document_with_geospatial_theme(
+        self, opensearch_client, mock_dataset_with_datetime, theme
+    ):
+        mock_dataset_with_datetime.dcat["theme"] = theme
+        mock_dataset_with_datetime.dcat.pop("spatial", None)
+        mock_dataset_with_datetime.translated_spatial = None
+
+        document = opensearch_client.dataset_to_document(mock_dataset_with_datetime)
+
+        assert document["has_spatial"] is True
+
+    @pytest.mark.parametrize("theme", [None, [], ["Health"], "Environment", "Spatial"])
+    def test_dataset_to_document_without_spatial_values_or_geospatial_theme(
+        self, opensearch_client, mock_dataset_with_datetime, theme
+    ):
+        mock_dataset_with_datetime.dcat["theme"] = theme
+        mock_dataset_with_datetime.dcat.pop("spatial", None)
+        mock_dataset_with_datetime.translated_spatial = None
+
+        document = opensearch_client.dataset_to_document(mock_dataset_with_datetime)
+
+        assert document["has_spatial"] is False
+
     def test_dataset_to_document_does_not_modify_original_dcat(
         self, opensearch_client, mock_dataset_with_datetime, mock_organization
     ):


### PR DESCRIPTION
For
- https://github.com/GSA/data.gov/issues/5949

## About
Updated geospatial classification for spatial filter. A dataset is now geospatial if any condition is true:

  - existing: dcat.spatial is not empty
  - existing: translated_spatial is not None
  - **NEW**: theme contains "geospatial" case-insensitively