### PR TITLE
add snyk scan

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,23 @@
+name: Snyk Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  snyk:
+    uses: GSA/data.gov/.github/workflows/snyk-template.yml@main
+    with:
+      all_projects: true
+      node_version: "20"
+      severity_threshold: medium
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/5956

Changes:
- Call the reusale workflow template to do snyk scan. 
- snyk scan on demand, on weekly schedule (monday morning), and on each PR
- failed weekly scan will have an issue created.